### PR TITLE
single tenant compatibility

### DIFF
--- a/packages/api/src/buildApp/router.ts
+++ b/packages/api/src/buildApp/router.ts
@@ -36,6 +36,9 @@ export default async function router(fastify: FastifyInstance) {
         }),
         f.register(userPropertiesController, { prefix: "/user-properties" }),
         f.register(usersController, { prefix: "/users" }),
+        // mount redundant webhooks controller at root level for backwards
+        // compatibility. this is the one exception to this route namespace being auth'd.
+        f.register(webhooksController, { prefix: "/webhooks" }),
       ]);
     },
     { prefix: "/api" }

--- a/packages/api/src/workspace.ts
+++ b/packages/api/src/workspace.ts
@@ -1,5 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import config from "backend-lib/src/config";
+import logger from "backend-lib/src/logger";
 import { FastifyRequest } from "fastify";
 import { WORKSPACE_ID_HEADER } from "isomorphic-lib/src/constants";
 import { schemaValidate } from "isomorphic-lib/src/resultHandling/schemaValidation";
@@ -13,6 +14,7 @@ export function getWorkspaceIdFromReq(req: FastifyRequest): string {
     null
   )?.workspaceId;
   if (bodyParam) {
+    logger().debug({ workspaceId: bodyParam }, "Found workspaceId in body.");
     return bodyParam;
   }
 
@@ -20,17 +22,21 @@ export function getWorkspaceIdFromReq(req: FastifyRequest): string {
     null
   )?.workspaceId;
   if (queryParam) {
+    logger().debug({ workspaceId: queryParam }, "Found workspaceId in query.");
     return queryParam;
   }
 
   const header = req.headers[WORKSPACE_ID_HEADER];
 
   if (header instanceof Array && header[0]) {
+    logger().debug({ workspaceId: header[0] }, "Found workspaceId in header.");
     return header[0];
   }
   if (header && typeof header === "string") {
+    logger().debug({ workspaceId: header }, "Found workspaceId in header.");
     return header;
   }
 
+  logger().debug("No workspaceId found in request.");
   return config().defaultWorkspaceId;
 }


### PR DESCRIPTION
- a backwards incompatible routing change was introduced when dittofeed was made to support its multi tenant auth mode
- adds a webhooks redundant mount, for backwards compatibility
- allows single tenant app users to be migrated to latest version
