### PR TITLE
more journey fixes

### DIFF
--- a/packages/dashboard/src/components/journeys/layoutNodes.ts
+++ b/packages/dashboard/src/components/journeys/layoutNodes.ts
@@ -6,11 +6,22 @@ import { NodeData } from "../../lib/types";
 
 export const nodeHeight = 200;
 
+const opt = dag.decrossOpt();
+const heuristic = dag.decrossTwoLayer();
+
+function decrossFallback(layers: dag.SugiNode[][]): void {
+  try {
+    opt(layers);
+  } catch {
+    heuristic(layers);
+  }
+}
+
 const dagLayout = dag
   .sugiyama()
-  .layering(dag.layeringLongestPath())
+  .layering(dag.layeringCoffmanGraham())
   .nodeSize(() => [400, nodeHeight])
-  .decross(dag.decrossOpt().large("large"))
+  .decross(decrossFallback)
   .coord(dag.coordCenter());
 
 // the layouting function

--- a/packages/dashboard/src/components/journeys/store.ts
+++ b/packages/dashboard/src/components/journeys/store.ts
@@ -763,6 +763,8 @@ export function journeyToState(
   let remainingNodes: [JourneyNode, string][] = [
     [firstBodyNode, JourneyNodeType.EntryNode],
   ];
+
+  const seenNodes = new Set<string>();
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, no-constant-condition
   while (true) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -774,6 +776,17 @@ export function journeyToState(
       }
       continue;
     }
+
+    if (node.type === JourneyNodeType.EntryNode) {
+      throw new Error("Entry node should already be handled");
+    }
+    if (seenNodes.has(node.id)) {
+      if (remainingNodes.length === 0) {
+        break;
+      }
+      continue;
+    }
+    seenNodes.add(node.id);
 
     const target = journeyEdges.find((e) => e.source === source)?.target;
 
@@ -892,11 +905,12 @@ export function journeyToState(
     }
   }
 
+  journeyNodes = layoutNodes(journeyNodes, journeyEdges);
   const journeyNodesIndex = buildNodesIndex(journeyNodes);
 
   return {
     journeyName: journey.name,
-    journeyNodes: layoutNodes(journeyNodes, journeyEdges),
+    journeyNodes,
     journeyEdges,
     journeyNodesIndex,
   };


### PR DESCRIPTION
- use decross heuristic for large journeys
- prevent duplicate nodes from being included
- ensure node indexing occurs after layout
