### PR TITLE
read query concurrency control

### DIFF
--- a/packages/backend-lib/package.json
+++ b/packages/backend-lib/package.json
@@ -49,7 +49,7 @@
     "minimist": "^1.2.7",
     "mjml": "^4.14.1",
     "neverthrow": "^6.0.0",
-    "p-queue": "^7.3.4",
+    "p-limit": "^3.1.0",
     "pino": "^8.11.0",
     "pino-pretty": "^10.0.0",
     "prisma": "^4.16.2",

--- a/packages/backend-lib/package.json
+++ b/packages/backend-lib/package.json
@@ -49,6 +49,7 @@
     "minimist": "^1.2.7",
     "mjml": "^4.14.1",
     "neverthrow": "^6.0.0",
+    "p-queue": "^7.3.4",
     "pino": "^8.11.0",
     "pino-pretty": "^10.0.0",
     "prisma": "^4.16.2",

--- a/packages/backend-lib/src/segments/computePropertiesWorkflow/activities/computeProperties.test.ts
+++ b/packages/backend-lib/src/segments/computePropertiesWorkflow/activities/computeProperties.test.ts
@@ -1613,7 +1613,6 @@ describe("compute properties activities", () => {
         describe("when activity called twice with the same parameters", () => {
           it("returns the same results but only sends the signals once", async () => {
             const currentTime = Date.parse("2022-01-01 00:15:45 UTC");
-            logger().debug("call 1");
 
             await computePropertiesPeriod({
               currentTime,
@@ -1624,7 +1623,6 @@ describe("compute properties activities", () => {
               userProperties: [],
             });
 
-            logger().debug("call 2");
             await computePropertiesPeriod({
               currentTime,
               workspaceId: workspace.id,

--- a/packages/backend-lib/src/segments/computePropertiesWorkflow/activities/computeProperties.test.ts
+++ b/packages/backend-lib/src/segments/computePropertiesWorkflow/activities/computeProperties.test.ts
@@ -16,7 +16,6 @@ import {
 } from "../../../constants";
 import { EMAIL_EVENTS_UP_DEFINITION } from "../../../integrations/subscriptions";
 import { enrichJourney } from "../../../journeys";
-import logger from "../../../logger";
 import prisma, { Prisma } from "../../../prisma";
 import { buildSubscriptionChangeEventInner } from "../../../subscriptionGroups";
 import {

--- a/packages/backend-lib/src/segments/computePropertiesWorkflow/activities/computeProperties.ts
+++ b/packages/backend-lib/src/segments/computePropertiesWorkflow/activities/computeProperties.ts
@@ -3,8 +3,12 @@ import { randomUUID } from "node:crypto";
 
 import { Row } from "@clickhouse/client";
 import { unwrap } from "isomorphic-lib/src/resultHandling/resultUtils";
-import { schemaValidate } from "isomorphic-lib/src/resultHandling/schemaValidation";
+import {
+  schemaValidate,
+  schemaValidateWithErr,
+} from "isomorphic-lib/src/resultHandling/schemaValidation";
 import { err, ok, Result } from "neverthrow";
+import PQueue from "p-queue";
 
 import {
   ClickHouseQueryBuilder,
@@ -316,6 +320,219 @@ function buildReadQuery({
   };
 }
 
+async function processRows({
+  rows,
+  workspaceId,
+  subscribedJourneys,
+}: {
+  rows: Row[];
+  workspaceId: string;
+  subscribedJourneys: EnrichedJourney[];
+}): Promise<boolean> {
+  let hasRows = false;
+  const assignments: ComputedAssignment[] = (
+    await Promise.all(
+      rows.map(async (row) => {
+        const json = await row.json();
+        const result = schemaValidateWithErr(json, ComputedAssignment);
+        if (result.isErr()) {
+          logger().error(
+            { err: result.error, json },
+            "failed to parse assignment json"
+          );
+          const emptyAssignments: ComputedAssignment[] = [];
+          return emptyAssignments;
+        }
+        return result.value;
+      })
+    )
+  ).flat();
+
+  const pgUserPropertyAssignments: ComputedAssignment[] = [];
+  const pgSegmentAssignments: ComputedAssignment[] = [];
+  const journeySegmentAssignments: ComputedAssignment[] = [];
+  const integrationAssignments: ComputedAssignment[] = [];
+
+  for (const assignment of assignments) {
+    hasRows = true;
+
+    let assignmentCategory: ComputedAssignment[];
+    if (assignment.processed_for_type === "pg") {
+      switch (assignment.type) {
+        case "segment":
+          assignmentCategory = pgSegmentAssignments;
+          break;
+        case "user_property":
+          assignmentCategory = pgUserPropertyAssignments;
+          break;
+      }
+    } else if (assignment.processed_for_type === "integration") {
+      assignmentCategory = integrationAssignments;
+    } else {
+      assignmentCategory = journeySegmentAssignments;
+    }
+    assignmentCategory.push(assignment);
+  }
+
+  logger().debug(
+    {
+      workspaceId,
+      assignmentsCount: assignments.length,
+      pgUserPropertyAssignmentsCount: pgUserPropertyAssignments.length,
+      pgSegmentAssignmentsCount: pgSegmentAssignments.length,
+      journeySegmentAssignmentsCount: journeySegmentAssignments.length,
+      integrationAssignmentsCount: integrationAssignments.length,
+    },
+    "processing computed assignments"
+  );
+
+  await Promise.all([
+    ...pgUserPropertyAssignments.map(async (a) => {
+      try {
+        await prisma().userPropertyAssignment.upsert({
+          where: {
+            workspaceId_userPropertyId_userId: {
+              workspaceId: a.workspace_id,
+              userId: a.user_id,
+              userPropertyId: a.computed_property_id,
+            },
+          },
+          update: {
+            value: a.latest_user_property_value,
+          },
+          create: {
+            workspaceId: a.workspace_id,
+            userId: a.user_id,
+            userPropertyId: a.computed_property_id,
+            value: a.latest_user_property_value,
+          },
+        });
+      } catch (e) {
+        // If reference error due to user assignment not existing anymore, swallow error and continue
+        if (
+          !(
+            e instanceof Prisma.PrismaClientKnownRequestError &&
+            e.code === "P2003"
+          )
+        ) {
+          throw e;
+        }
+      }
+    }),
+    ...pgSegmentAssignments.map(async (a) => {
+      const inSegment = Boolean(a.latest_segment_value);
+      try {
+        await prisma().segmentAssignment.upsert({
+          where: {
+            workspaceId_userId_segmentId: {
+              workspaceId: a.workspace_id,
+              userId: a.user_id,
+              segmentId: a.computed_property_id,
+            },
+          },
+          update: {
+            inSegment,
+          },
+          create: {
+            workspaceId: a.workspace_id,
+            userId: a.user_id,
+            segmentId: a.computed_property_id,
+            inSegment,
+          },
+        });
+      } catch (e) {
+        // If reference error due to segment not existing anymore, swallow error and continue
+        if (
+          !(
+            e instanceof Prisma.PrismaClientKnownRequestError &&
+            e.code === "P2003"
+          )
+        ) {
+          throw e;
+        }
+      }
+    }),
+  ]);
+
+  await Promise.all([
+    ...journeySegmentAssignments.flatMap((assignment) => {
+      const journey = subscribedJourneys.find(
+        (j) => j.id === assignment.processed_for
+      );
+      if (!journey) {
+        logger().error(
+          {
+            subscribedJourneys: subscribedJourneys.map((j) => j.id),
+            processed_for: assignment.processed_for,
+          },
+          "journey in assignment.processed_for missing from subscribed journeys"
+        );
+        return [];
+      }
+
+      return signalJourney({
+        workspaceId,
+        segmentId: assignment.computed_property_id,
+        segmentAssignment: assignment,
+        journey,
+      });
+    }),
+    ...integrationAssignments.flatMap(async (assignment) => {
+      switch (assignment.processed_for) {
+        case HUBSPOT_INTEGRATION: {
+          const { workflowClient } = getContext();
+          const updateVersion = new Date(assignment.max_assigned_at).getTime();
+
+          const update: ComputedPropertyUpdate =
+            assignment.type === "segment"
+              ? {
+                  type: "segment",
+                  segmentId: assignment.computed_property_id,
+                  segmentVersion: updateVersion,
+                  currentlyInSegment: assignment.latest_segment_value,
+                }
+              : {
+                  type: "user_property",
+                  userPropertyId: assignment.computed_property_id,
+                  value: assignment.latest_user_property_value,
+                  userPropertyVersion: updateVersion,
+                };
+
+          return startHubspotUserIntegrationWorkflow({
+            workspaceId: assignment.workspace_id,
+            userId: assignment.user_id,
+            workflowClient,
+            update,
+          });
+        }
+        default:
+          logger().error(
+            {
+              workspaceId,
+              assignment,
+            },
+            "integration in assignment.processed_for missing from subscribed integrations"
+          );
+          return [];
+      }
+    }),
+  ]);
+
+  const processedAssignments: ComputedPropertyAssignment[] =
+    assignments.flatMap((assignment) => ({
+      user_property_value: assignment.latest_user_property_value,
+      segment_value: assignment.latest_segment_value,
+      ...assignment,
+    }));
+
+  await insertProcessedComputedProperties({
+    assignments: processedAssignments,
+  });
+  return hasRows;
+}
+
+const queue = new PQueue({ concurrency: 2 });
+
 // TODO distinguish between recoverable and non recoverable errors
 // TODO signal back to workflow with query id, so that query can be safely restarted part way through
 export async function computePropertiesPeriodSafe({
@@ -425,208 +642,46 @@ export async function computePropertiesPeriodSafe({
       );
 
       let hasRows = false;
-      for await (const rows of resultSet.stream()) {
-        const assignments: ComputedAssignment[] = await Promise.all(
-          rows.flatMap(async (row: Row) => {
-            const json = await row.json();
-            logger().debug({ json }, "processing assignment json");
-            const result = schemaValidate(json, ComputedAssignment);
-            if (result.isErr()) {
-              logger().error(
-                { err: result.error, json },
-                "failed to parse assignment json"
-              );
-              return [];
-            }
-            return result.value;
-          })
-        );
+      let unprocessedRowSets = 0;
+      let hasEnded = false;
+      let hasFailed = false;
+      const stream = resultSet.stream();
 
-        const pgUserPropertyAssignments: ComputedAssignment[] = [];
-        const pgSegmentAssignments: ComputedAssignment[] = [];
-        const journeySegmentAssignments: ComputedAssignment[] = [];
-        const integrationAssignments: ComputedAssignment[] = [];
-
-        for (const assignment of assignments) {
-          hasRows = true;
-
-          let assignmentCategory: ComputedAssignment[];
-          if (assignment.processed_for_type === "pg") {
-            switch (assignment.type) {
-              case "segment":
-                assignmentCategory = pgSegmentAssignments;
-                break;
-              case "user_property":
-                assignmentCategory = pgUserPropertyAssignments;
-                break;
-            }
-          } else if (assignment.processed_for_type === "integration") {
-            assignmentCategory = integrationAssignments;
-          } else {
-            assignmentCategory = journeySegmentAssignments;
+      await new Promise((resolve, reject) => {
+        stream.on("data", (rows: Row[]) => {
+          if (hasFailed) {
+            return;
           }
-          assignmentCategory.push(assignment);
-        }
 
-        logger().debug(
-          {
-            workspaceId,
-            assignmentsCount: assignments.length,
-            pgUserPropertyAssignmentsCount: pgUserPropertyAssignments.length,
-            pgSegmentAssignmentsCount: pgSegmentAssignments.length,
-            journeySegmentAssignmentsCount: journeySegmentAssignments.length,
-            integrationAssignmentsCount: integrationAssignments.length,
-          },
-          "processing computed assignments"
-        );
+          (async () => {
+            unprocessedRowSets += 1;
 
-        await Promise.all([
-          ...pgUserPropertyAssignments.map(async (a) => {
             try {
-              await prisma().userPropertyAssignment.upsert({
-                where: {
-                  workspaceId_userPropertyId_userId: {
-                    workspaceId: a.workspace_id,
-                    userId: a.user_id,
-                    userPropertyId: a.computed_property_id,
-                  },
-                },
-                update: {
-                  value: a.latest_user_property_value,
-                },
-                create: {
-                  workspaceId: a.workspace_id,
-                  userId: a.user_id,
-                  userPropertyId: a.computed_property_id,
-                  value: a.latest_user_property_value,
-                },
-              });
+              hasRows =
+                (await queue.add(() =>
+                  processRows({ rows, workspaceId, subscribedJourneys })
+                )) || hasRows;
             } catch (e) {
-              // If reference error due to user assignment not existing anymore, swallow error and continue
-              if (
-                !(
-                  e instanceof Prisma.PrismaClientKnownRequestError &&
-                  e.code === "P2003"
-                )
-              ) {
-                throw e;
-              }
-            }
-          }),
-          ...pgSegmentAssignments.map(async (a) => {
-            const inSegment = Boolean(a.latest_segment_value);
-            try {
-              await prisma().segmentAssignment.upsert({
-                where: {
-                  workspaceId_userId_segmentId: {
-                    workspaceId: a.workspace_id,
-                    userId: a.user_id,
-                    segmentId: a.computed_property_id,
-                  },
-                },
-                update: {
-                  inSegment,
-                },
-                create: {
-                  workspaceId: a.workspace_id,
-                  userId: a.user_id,
-                  segmentId: a.computed_property_id,
-                  inSegment,
-                },
-              });
-            } catch (e) {
-              // If reference error due to segment not existing anymore, swallow error and continue
-              if (
-                !(
-                  e instanceof Prisma.PrismaClientKnownRequestError &&
-                  e.code === "P2003"
-                )
-              ) {
-                throw e;
-              }
-            }
-          }),
-        ]);
-
-        await Promise.all([
-          ...journeySegmentAssignments.flatMap((assignment) => {
-            const journey = subscribedJourneys.find(
-              (j) => j.id === assignment.processed_for
-            );
-            if (!journey) {
-              logger().error(
-                {
-                  subscribedJourneys: subscribedJourneys.map((j) => j.id),
-                  processed_for: assignment.processed_for,
-                },
-                "journey in assignment.processed_for missing from subscribed journeys"
-              );
-              return [];
+              hasFailed = true;
+              reject(e);
+              return;
             }
 
-            return signalJourney({
-              workspaceId,
-              segmentId: assignment.computed_property_id,
-              segmentAssignment: assignment,
-              journey,
-            });
-          }),
-          ...integrationAssignments.flatMap(async (assignment) => {
-            switch (assignment.processed_for) {
-              case HUBSPOT_INTEGRATION: {
-                const { workflowClient } = getContext();
-                const updateVersion = new Date(
-                  assignment.max_assigned_at
-                ).getTime();
-
-                const update: ComputedPropertyUpdate =
-                  assignment.type === "segment"
-                    ? {
-                        type: "segment",
-                        segmentId: assignment.computed_property_id,
-                        segmentVersion: updateVersion,
-                        currentlyInSegment: assignment.latest_segment_value,
-                      }
-                    : {
-                        type: "user_property",
-                        userPropertyId: assignment.computed_property_id,
-                        value: assignment.latest_user_property_value,
-                        userPropertyVersion: updateVersion,
-                      };
-
-                return startHubspotUserIntegrationWorkflow({
-                  workspaceId: assignment.workspace_id,
-                  userId: assignment.user_id,
-                  workflowClient,
-                  update,
-                });
-              }
-              default:
-                logger().error(
-                  {
-                    workspaceId,
-                    assignment,
-                  },
-                  "integration in assignment.processed_for missing from subscribed integrations"
-                );
-                return [];
+            unprocessedRowSets -= 1;
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (!hasFailed && hasEnded && unprocessedRowSets === 0) {
+              resolve(0);
             }
-          }),
-        ]);
-
-        const processedAssignments: ComputedPropertyAssignment[] =
-          assignments.flatMap((assignment) => ({
-            user_property_value: assignment.latest_user_property_value,
-            segment_value: assignment.latest_segment_value,
-            ...assignment,
-          }));
-
-        await insertProcessedComputedProperties({
-          assignments: processedAssignments,
+          })();
         });
-      }
+
+        stream.on("end", () => {
+          hasEnded = true;
+        });
+      });
 
       // If no rows were fetched in this iteration, break out of the loop.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!hasRows) {
         break;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6676,6 +6676,7 @@ __metadata:
     minimist: ^1.2.7
     mjml: ^4.14.1
     neverthrow: ^6.0.0
+    p-queue: ^7.3.4
     pino: ^8.11.0
     pino-pretty: ^10.0.0
     prettier: ^2.8.3
@@ -9134,6 +9135,13 @@ __metadata:
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
   checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
+  languageName: node
+  linkType: hard
+
+"eventemitter3@npm:^4.0.7":
+  version: 4.0.7
+  resolution: "eventemitter3@npm:4.0.7"
+  checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
   languageName: node
   linkType: hard
 
@@ -14265,6 +14273,23 @@ __metadata:
   dependencies:
     aggregate-error: ^3.0.0
   checksum: cb0ab21ec0f32ddffd31dfc250e3afa61e103ef43d957cc45497afe37513634589316de4eb88abdfd969fe6410c22c0b93ab24328833b8eb1ccc087fc0442a1c
+  languageName: node
+  linkType: hard
+
+"p-queue@npm:^7.3.4":
+  version: 7.3.4
+  resolution: "p-queue@npm:7.3.4"
+  dependencies:
+    eventemitter3: ^4.0.7
+    p-timeout: ^5.0.2
+  checksum: a21b8a4dd75f64a4988e4468cc344d1b45132506ddd2c771932d3de446d108ee68713b629e0d3f0809c227bc10eafc613edde6ae741d9f60db89b6031e40921c
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^5.0.2":
+  version: 5.1.0
+  resolution: "p-timeout@npm:5.1.0"
+  checksum: f5cd4e17301ff1ff1d8dbf2817df0ad88c6bba99349fc24d8d181827176ad4f8aca649190b8a5b1a428dfd6ddc091af4606835d3e0cb0656e04045da5c9e270c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6676,7 +6676,7 @@ __metadata:
     minimist: ^1.2.7
     mjml: ^4.14.1
     neverthrow: ^6.0.0
-    p-queue: ^7.3.4
+    p-limit: ^3.1.0
     pino: ^8.11.0
     pino-pretty: ^10.0.0
     prettier: ^2.8.3
@@ -9135,13 +9135,6 @@ __metadata:
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
   checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
-  languageName: node
-  linkType: hard
-
-"eventemitter3@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "eventemitter3@npm:4.0.7"
-  checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
   languageName: node
   linkType: hard
 
@@ -14273,23 +14266,6 @@ __metadata:
   dependencies:
     aggregate-error: ^3.0.0
   checksum: cb0ab21ec0f32ddffd31dfc250e3afa61e103ef43d957cc45497afe37513634589316de4eb88abdfd969fe6410c22c0b93ab24328833b8eb1ccc087fc0442a1c
-  languageName: node
-  linkType: hard
-
-"p-queue@npm:^7.3.4":
-  version: 7.3.4
-  resolution: "p-queue@npm:7.3.4"
-  dependencies:
-    eventemitter3: ^4.0.7
-    p-timeout: ^5.0.2
-  checksum: a21b8a4dd75f64a4988e4468cc344d1b45132506ddd2c771932d3de446d108ee68713b629e0d3f0809c227bc10eafc613edde6ae741d9f60db89b6031e40921c
-  languageName: node
-  linkType: hard
-
-"p-timeout@npm:^5.0.2":
-  version: 5.1.0
-  resolution: "p-timeout@npm:5.1.0"
-  checksum: f5cd4e17301ff1ff1d8dbf2817df0ad88c6bba99349fc24d8d181827176ad4f8aca649190b8a5b1a428dfd6ddc091af4606835d3e0cb0656e04045da5c9e270c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- limit read queries to concurrency of 2
- remove redundant pagination call
- switch from async loops to streams
- close session client after operation
