### PR TITLE
render lite single tenant simplification

### DIFF
--- a/packages/backend-lib/src/config.ts
+++ b/packages/backend-lib/src/config.ts
@@ -72,8 +72,6 @@ const BaseRawConfigProps = {
     Type.String({ format: "naturalNumber" })
   ),
   secretKey: Type.Optional(Type.String()),
-  secretKey1: Type.Optional(Type.String()),
-  secretKey2: Type.Optional(Type.String()),
   password: Type.Optional(Type.String()),
 };
 
@@ -137,7 +135,7 @@ const RawConfig = Type.Union([
 
 type RawConfig = Static<typeof RawConfig>;
 
-export type Config = Omit<
+export type Config =
   Overwrite<
     RawConfig,
     {
@@ -175,8 +173,6 @@ export type Config = Omit<
   > & {
     defaultUserEventsTableVersion: string;
   },
-  "secretKey1" | "secretKey2"
->;
 
 const defaultDbParams: Record<string, string> = {
   connect_timeout: "60",
@@ -295,12 +291,7 @@ function parseRawConfig(rawConfig: RawConfig): Config {
   }
 
   const authMode = rawConfig.authMode ?? "anonymous";
-  // Some environments (e.g. render) don't allow generate secrets of sufficient
-  // length, and this is a workaround
-  const secretKey =
-    rawConfig.secretKey1 && rawConfig.secretKey2
-      ? `${rawConfig.secretKey1}${rawConfig.secretKey2}`
-      : rawConfig.secretKey;
+  const { secretKey } = rawConfig;
 
   if (authMode === "single-tenant" && (!secretKey || !rawConfig.password)) {
     throw new Error(

--- a/packages/backend-lib/src/config.ts
+++ b/packages/backend-lib/src/config.ts
@@ -135,44 +135,43 @@ const RawConfig = Type.Union([
 
 type RawConfig = Static<typeof RawConfig>;
 
-export type Config =
-  Overwrite<
-    RawConfig,
-    {
-      kafkaBrokers: string[];
-      computedPropertiesTopicName: string;
-      userEventsTopicName: string;
-      temporalNamespace: string;
-      databaseUrl: string;
-      clickhouseHost: string;
-      clickhouseDatabase: string;
-      kafkaSsl: boolean;
-      nodeEnv: NodeEnvEnum;
-      temporalAddress: string;
-      logConfig: boolean;
-      bootstrapEvents: boolean;
-      kafkaUserEventsPartitions: number;
-      kafkaUserEventsReplicationFactor: number;
-      kafkaSaslMechanism: KafkaSaslMechanism;
-      bootstrapWorker: boolean;
-      writeMode: WriteMode;
-      otelCollector: string;
-      startOtel: boolean;
-      logLevel: LogLevel;
-      prettyLogs: boolean;
-      googleOps: boolean;
-      enableSourceControl: boolean;
-      authMode: AuthMode;
-      trackDashboard: boolean;
-      dashboardUrl: string;
-      enableMobilePush: boolean;
-      readQueryPageSize: number;
-      readQueryConcurrency: number;
-      computePropertiesInterval: number;
-    }
-  > & {
-    defaultUserEventsTableVersion: string;
-  },
+export type Config = Overwrite<
+  RawConfig,
+  {
+    kafkaBrokers: string[];
+    computedPropertiesTopicName: string;
+    userEventsTopicName: string;
+    temporalNamespace: string;
+    databaseUrl: string;
+    clickhouseHost: string;
+    clickhouseDatabase: string;
+    kafkaSsl: boolean;
+    nodeEnv: NodeEnvEnum;
+    temporalAddress: string;
+    logConfig: boolean;
+    bootstrapEvents: boolean;
+    kafkaUserEventsPartitions: number;
+    kafkaUserEventsReplicationFactor: number;
+    kafkaSaslMechanism: KafkaSaslMechanism;
+    bootstrapWorker: boolean;
+    writeMode: WriteMode;
+    otelCollector: string;
+    startOtel: boolean;
+    logLevel: LogLevel;
+    prettyLogs: boolean;
+    googleOps: boolean;
+    enableSourceControl: boolean;
+    authMode: AuthMode;
+    trackDashboard: boolean;
+    dashboardUrl: string;
+    enableMobilePush: boolean;
+    readQueryPageSize: number;
+    readQueryConcurrency: number;
+    computePropertiesInterval: number;
+  }
+> & {
+  defaultUserEventsTableVersion: string;
+};
 
 const defaultDbParams: Record<string, string> = {
   connect_timeout: "60",

--- a/render.yaml
+++ b/render.yaml
@@ -76,12 +76,7 @@ services:
           property: host
       - key: PASSWORD
         sync: false
-      # Concatenating two random keys for
-      # secret key because render's generated values are 24 bytes long, not 32 as
-      # advertised.
-      - key: SECRET_KEY1
-        generateValue: true
-      - key: SECRET_KEY2
+      - key: SECRET_KEY
         generateValue: true
   - type: pserv
     name: dittofeed-ch


### PR DESCRIPTION
- render fixed a bug which caused their generated secrets to be 24 bytes instead of 32, on our request