### PR TITLE
complex trait user properties

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -168,7 +168,7 @@ services:
     networks:
       - dittofeed-network-dev
   clickhouse-server:
-    image: clickhouse/clickhouse-server:22.9.5.25-alpine
+    image: clickhouse/clickhouse-server:23.8.8.20-alpine
     ports:
       - "8123:8123"
       - "9000:9000"

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
@@ -1854,7 +1854,6 @@ describe("computeProperties", () => {
       description:
         "when a performed segment is updated with a new performed count threshold",
       userProperties: [],
-      only: true,
       segments: [
         {
           name: "updatedPerformed",
@@ -1931,6 +1930,37 @@ describe("computeProperties", () => {
               id: "user-1",
               segments: {
                 updatedPerformed: false,
+              },
+            },
+          ],
+        },
+        {
+          type: EventsStepType.Sleep,
+          timeMs: 1000,
+        },
+        {
+          type: EventsStepType.SubmitEvents,
+          events: [
+            {
+              userId: "user-1",
+              offsetMs: -100,
+              type: EventType.Track,
+              event: "test",
+            },
+          ],
+        },
+        {
+          type: EventsStepType.ComputeProperties,
+        },
+        {
+          type: EventsStepType.Assert,
+          description:
+            "after receiving another event user satisfies new segment definition",
+          users: [
+            {
+              id: "user-1",
+              segments: {
+                updatedPerformed: true,
               },
             },
           ],

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
@@ -1463,7 +1463,6 @@ describe("computeProperties", () => {
     },
     {
       description: "with a performed many user property",
-      only: true,
       userProperties: [
         {
           name: "performedMany",

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
@@ -1463,6 +1463,7 @@ describe("computeProperties", () => {
     },
     {
       description: "with a performed many user property",
+      only: true,
       userProperties: [
         {
           name: "performedMany",
@@ -1718,7 +1719,6 @@ describe("computeProperties", () => {
     },
     {
       description: "with a trait user property with a complex inner structure",
-      only: true,
       userProperties: [
         {
           name: "complex",

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
@@ -1716,6 +1716,61 @@ describe("computeProperties", () => {
         },
       ],
     },
+    {
+      description: "with a trait user property with a complex inner structure",
+      only: true,
+      userProperties: [
+        {
+          name: "complex",
+          definition: {
+            type: UserPropertyDefinitionType.Trait,
+            path: "obj1",
+          },
+        },
+      ],
+      segments: [],
+      steps: [
+        {
+          type: EventsStepType.SubmitEvents,
+          events: [
+            {
+              userId: "user-1",
+              offsetMs: -100,
+              type: EventType.Identify,
+              traits: {
+                obj1: {
+                  prop1: "value1",
+                  obj2: {
+                    prop2: "value2",
+                    prop3: ["value3", "value4"],
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          type: EventsStepType.ComputeProperties,
+        },
+        {
+          type: EventsStepType.Assert,
+          users: [
+            {
+              id: "user-1",
+              properties: {
+                complex: {
+                  prop1: "value1",
+                  obj2: {
+                    prop2: "value2",
+                    prop3: ["value3", "value4"],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
   ];
   const only: null | string =
     tests.find((t) => t.only === true)?.description ?? null;

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
@@ -1280,7 +1280,6 @@ function constructAssignmentsQuery({
     segmentValue = ac.query;
   } else {
     segmentValue = "False";
-    // userPropertyValue = `toJSONString(ifNull(${ac.query}, ''))`;
     userPropertyValue = ac.query;
   }
   const query = `

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
@@ -536,18 +536,12 @@ function leafUserPropertyToSubQuery({
   userProperty: SavedUserPropertyResource;
   child: LeafUserPropertyDefinition;
   qb: ClickHouseQueryBuilder;
-}): SubQueryData {
+}): SubQueryData | null {
   switch (child.type) {
     case UserPropertyDefinitionType.Trait: {
       const stateId = userPropertyStateId(userProperty, child.id);
-      // FIXME return null here
       if (child.path.length === 0) {
-        return {
-          condition: `0`,
-          type: "user_property",
-          stateId,
-          computedPropertyId: userProperty.id,
-        };
+        return null;
       }
       const path = qb.addQueryValue(`$.${child.path}`, "String");
       return {
@@ -612,22 +606,28 @@ function groupedUserPropertyToSubQuery({
       });
     }
     case UserPropertyDefinitionType.Trait: {
-      return [
-        leafUserPropertyToSubQuery({
-          userProperty,
-          child: node,
-          qb,
-        }),
-      ];
+      const subQuery = leafUserPropertyToSubQuery({
+        userProperty,
+        child: node,
+        qb,
+      });
+
+      if (!subQuery) {
+        return [];
+      }
+      return [subQuery];
     }
     case UserPropertyDefinitionType.Performed: {
-      return [
-        leafUserPropertyToSubQuery({
-          userProperty,
-          child: node,
-          qb,
-        }),
-      ];
+      const subQuery = leafUserPropertyToSubQuery({
+        userProperty,
+        child: node,
+        qb,
+      });
+
+      if (!subQuery) {
+        return [];
+      }
+      return [subQuery];
     }
   }
 }
@@ -642,22 +642,28 @@ function userPropertyToSubQuery({
   const stateId = userPropertyStateId(userProperty);
   switch (userProperty.definition.type) {
     case UserPropertyDefinitionType.Trait: {
-      return [
-        leafUserPropertyToSubQuery({
-          userProperty,
-          child: userProperty.definition,
-          qb,
-        }),
-      ];
+      const subQuery = leafUserPropertyToSubQuery({
+        userProperty,
+        child: userProperty.definition,
+        qb,
+      });
+
+      if (!subQuery) {
+        return [];
+      }
+      return [subQuery];
     }
     case UserPropertyDefinitionType.Performed: {
-      return [
-        leafUserPropertyToSubQuery({
-          userProperty,
-          child: userProperty.definition,
-          qb,
-        }),
-      ];
+      const subQuery = leafUserPropertyToSubQuery({
+        userProperty,
+        child: userProperty.definition,
+        qb,
+      });
+
+      if (!subQuery) {
+        return [];
+      }
+      return [subQuery];
     }
     case UserPropertyDefinitionType.Group: {
       const entryId = userProperty.definition.entry;

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
@@ -560,7 +560,6 @@ function leafUserPropertyToSubQuery({
       };
     }
     case UserPropertyDefinitionType.Performed: {
-      // FIXME test with nested
       const stateId = userPropertyStateId(userProperty, child.id);
       const path = qb.addQueryValue(child.path, "String");
       return {
@@ -882,7 +881,7 @@ function userPropertyToAssignment({
                   'timestamp',
                   formatDateTime(
                     event.2,
-                    '%Y-%m-%dT%H:%M:%S'
+                    '%Y-%m-%dT%H:%i:%S'
                   ),
                   'properties',
                   event.3

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
@@ -1228,7 +1228,8 @@ function constructAssignmentsQuery({
     segmentValue = ac.query;
   } else {
     segmentValue = "False";
-    userPropertyValue = `toJSONString(ifNull(${ac.query}, ''))`;
+    // userPropertyValue = `toJSONString(ifNull(${ac.query}, ''))`;
+    userPropertyValue = ac.query;
   }
   const query = `
     insert into computed_property_assignments_v2

--- a/packages/isomorphic-lib/src/resultHandling/schemaValidation.ts
+++ b/packages/isomorphic-lib/src/resultHandling/schemaValidation.ts
@@ -36,6 +36,8 @@ export function jsonParseSafe(s: string): Result<JSONValue, Error> {
   try {
     return ok(JSON.parse(s));
   } catch (e) {
-    return err(e as Error);
+    const error = new Error(`Failed to parse JSON: ${s}`);
+    error.cause = e;
+    return err(error);
   }
 }

--- a/packages/isomorphic-lib/src/userProperties.ts
+++ b/packages/isomorphic-lib/src/userProperties.ts
@@ -11,39 +11,6 @@ import {
   UserPropertyDefinitionType,
 } from "./types";
 
-function processPerformedManyValueV1(
-  definition: UserPropertyDefinition,
-  value: JSONValue
-): Result<JSONValue, Error> {
-  if (typeof value !== "string") {
-    return err(new Error("performed many value is not a string"));
-  }
-  const jsonParsedValue = jsonParseSafe(value);
-  if (jsonParsedValue.isErr()) {
-    return err(jsonParsedValue.error);
-  }
-  if (!(jsonParsedValue.value instanceof Array)) {
-    return err(new Error("performed many json parsed value is not an array"));
-  }
-
-  return ok(
-    jsonParsedValue.value.flatMap((item) => {
-      const result = schemaValidateWithErr(item, PerformedManyValueItem);
-      if (result.isErr()) {
-        return [];
-      }
-      const parsedProperties = jsonParseSafe(result.value.properties);
-      if (parsedProperties.isErr()) {
-        return [];
-      }
-      return {
-        ...result.value,
-        properties: parsedProperties.value,
-      };
-    })
-  );
-}
-
 function processUserProperty(
   definition: UserPropertyDefinition,
   value: JSONValue

--- a/packages/isomorphic-lib/src/userProperties.ts
+++ b/packages/isomorphic-lib/src/userProperties.ts
@@ -57,7 +57,7 @@ export function parseUserProperty(
 ): Result<JSONValue, Error> {
   const parsed = jsonParseSafe(value);
   if (parsed.isErr()) {
-    return err(parsed.error);
+    return ok(value);
   }
   const processed = processUserProperty(definition, parsed.value);
   if (processed.isErr()) {

--- a/packages/isomorphic-lib/src/userProperties.ts
+++ b/packages/isomorphic-lib/src/userProperties.ts
@@ -18,6 +18,7 @@ function processUserProperty(
   switch (definition.type) {
     case UserPropertyDefinitionType.PerformedMany: {
       if (typeof value !== "string") {
+        console.log("value", value);
         return err(new Error("performed many value is not a string"));
       }
       const jsonParsedValue = jsonParseSafe(value);


### PR DESCRIPTION
- allow Trait user properties to represent nested JSON structures, including objects and arrays
- upgrade local clickhouse to 23.8.8.20 to access the function_json_value_return_type_allow_complex setting
- fix bug in incremental computed properties logic, allowing definitionUpdatedAt to be used to reset computed properties
