### PR TITLE
fix click tracking for sendgrid

### DIFF
--- a/packages/api/src/controllers/contentController.ts
+++ b/packages/api/src/controllers/contentController.ts
@@ -136,12 +136,21 @@ export default async function contentController(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
+      const messageTags: Record<string, string> = {
+        channel: request.body.channel,
+      };
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const userId = request.body.userProperties.id;
+      if (typeof userId === "string") {
+        messageTags.userId = userId;
+      }
       const result = await sendMessage({
         workspaceId: request.body.workspaceId,
         templateId: request.body.templateId,
         userPropertyAssignments: request.body.userProperties,
         channel: request.body.channel,
         useDraft: true,
+        messageTags,
       });
       if (result.isOk()) {
         return reply.status(200).send({

--- a/packages/api/src/controllers/webhooksController.ts
+++ b/packages/api/src/controllers/webhooksController.ts
@@ -34,6 +34,8 @@ export default async function webhookController(fastify: FastifyInstance) {
         body: Type.Array(SendgridEvent),
       },
     },
+    // disabling lint rule because we need to accept any typed values from sendgrid
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment */
     async (request, reply) => {
       logger().debug({ body: request.body }, "Received sendgrid events.");
       // TODO allow for multiple workspaces on a single sendgrid account
@@ -106,6 +108,7 @@ export default async function webhookController(fastify: FastifyInstance) {
       });
       return reply.status(200).send();
     }
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment */
   );
 
   fastify.withTypeProvider<TypeBoxTypeProvider>().post(

--- a/packages/backend-lib/src/types.ts
+++ b/packages/backend-lib/src/types.ts
@@ -176,7 +176,7 @@ export const SendgridEvent = Type.Intersect([
       })
     ),
   }),
-  Type.Record(Type.String(), Type.String()),
+  Type.Record(Type.String(), Type.Any()),
 ]);
 
 export type SendgridEvent = Static<typeof SendgridEvent>;


### PR DESCRIPTION
- sendgrid click events were 400'ing due to the presence of the
  url_offset property
- ensure userId tag set on sendgrid test messages
