### PR TITLE
patch: remove internal user properties from being selected

### DIFF
--- a/packages/backend-lib/src/users.ts
+++ b/packages/backend-lib/src/users.ts
@@ -178,6 +178,7 @@ export async function getUsers({
               AND "userId" IN (SELECT "userId" FROM unique_user_ids)
               AND "value" != ''
               AND "value" != '""'
+              AND up."resourceType" != 'Internal'
 
           UNION ALL
 


### PR DESCRIPTION
Fixes #580 
/claim #580

Description: Added an extra `WHERE` clause in the SQL for `getUsers` to not select any user property that has `resourceType` `Internal`
```sql
AND up."resourceType" != 'Internal'
```