### PR TITLE
CI: Validate `open-api.json`

### DIFF
--- a/.github/workflows/shared-workflow.yaml
+++ b/.github/workflows/shared-workflow.yaml
@@ -38,3 +38,18 @@ jobs:
 
     - name: Run Typecheck
       run: yarn workspace ${{ inputs.package-name }} check
+
+    - name: Start API server
+      run: nohup yarn workspace api dev &
+      if: ${{ inputs.is_backend == 'true' }}
+
+    - name: Check if Open API documentation needs updating
+      if: ${{ inputs.is_backend == 'true' }}
+      run: |
+       until curl -s -o /dev/null -w "%{http_code}" "http://localhost:3001/documentation/json" | grep -q "200"; do
+       echo "Waiting for API server to be up..."
+       sleep 2
+       done
+       curl "http://localhost:3001/documentation/json" | jq "." > packages/docs/open-api.json
+       git diff --quiet packages/docs/open-api.json || { echo >&2 "Error: Please update open-api.json file by running: 
+       curl 'http://localhost:3001/documentation/json' | jq '.' > packages/docs/open-api.json"; exit 1; }


### PR DESCRIPTION
Successful CI [Run](https://github.com/neo773/dittofeed/actions/runs/7808012735/job/21297485745?pr=10#step:7:29)

/closes #643
/claim #643