### PR TITLE
feat: persisting event page search in url state

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -55,6 +55,7 @@
     "react-device-detect": "^2.2.2",
     "react-diff-view": "^3.0.3",
     "react-dom": "18.2.0",
+    "react-router-dom": "^6.22.1",
     "reactflow": "^11.2.0",
     "remeda": "^1.24.0",
     "simplebar-react": "^2.4.3",


### PR DESCRIPTION
**_What this PR do ?_**

-The state variable `selectedEventId` is updated when an event is selected from the table.

-Browser's URL state updates with the selected event's ID.so the page reflects the selected event even after a reload.
selected event ID is extracted from the URL state. This ensures that the component reflects the correct selected event when the page is loaded or when the URL changes.

-`search Term` state variable tracks the search term locally. Whenever the searchTerm state variable changes, the useEffect hook is triggered. It updates the URL state with the new search term value.

-URL state can be updated with relevant information such as page number, page size, search term, and selected event, so the component ensures that the page state can be preserved even after a reload.

/fix #637 
/claim #637