### PR TITLE
improve prettier setup

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+// necessary to prevent cursor / vscode prettier extension from providing its
+// own default settings 😠
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^29.4.0",
     "jest-expect-message": "^1.1.3",
-    "prettier": "3.2.4",
+    "prettier": "3.2.5",
     "prettier-eslint": "^16.3.0",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",

--- a/packages/admin-cli/package.json
+++ b/packages/admin-cli/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^29.4.0",
     "jest-expect-message": "^1.1.3",
-    "prettier": "^2.8.3",
+    "prettier": "^3.2.5",
     "ts-jest": "^29.0.5",
     "typescript": "^5.2.2"
   }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -72,7 +72,7 @@
     "fastify-tsconfig": "^1.0.1",
     "jest": "^29.4.0",
     "jest-expect-message": "^1.1.3",
-    "prettier": "3.2.4",
+    "prettier": "3.2.5",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",

--- a/packages/backend-lib/package.json
+++ b/packages/backend-lib/package.json
@@ -95,7 +95,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^29.4.0",
     "jest-expect-message": "^1.1.3",
-    "prettier": "3.2.4",
+    "prettier": "3.2.5",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -92,7 +92,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^29.4.0",
     "jest-expect-message": "^1.1.3",
-    "prettier": "3.2.4",
+    "prettier": "3.2.5",
     "ts-jest": "^29.0.5",
     "typescript": "^5.2.2",
     "utility-types": "^3.10.0"

--- a/packages/isomorphic-lib/package.json
+++ b/packages/isomorphic-lib/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^29.4.0",
     "jest-expect-message": "^1.1.3",
-    "prettier": "3.2.4",
+    "prettier": "3.2.5",
     "ts-jest": "^29.0.5",
     "typescript": "^5.2.2"
   },

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^29.4.0",
     "jest-expect-message": "^1.1.3",
-    "prettier": "3.2.4",
+    "prettier": "3.2.5",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "tsc-watch": "^6.0.0",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^29.4.0",
     "jest-expect-message": "^1.1.3",
-    "prettier": "3.2.4",
+    "prettier": "3.2.5",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "tsc-watch": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7174,7 +7174,7 @@ __metadata:
     isomorphic-lib: 0.0.3
     jest: ^29.4.0
     jest-expect-message: ^1.1.3
-    prettier: ^2.8.3
+    prettier: ^3.2.5
     remeda: ^1.12.0
     ts-jest: ^29.0.5
     ts-node: ^10.9.1
@@ -7423,7 +7423,7 @@ __metadata:
     neverthrow: ^6.0.0
     openapi-types: ^12.1.0
     postmark: ^4.0.2
-    prettier: 3.2.4
+    prettier: 3.2.5
     remeda: ^1.12.0
     resend: ^2.1.0
     svix: ^1.15.0
@@ -7890,7 +7890,7 @@ __metadata:
     pino: ^8.11.0
     pino-pretty: ^10.0.0
     postmark: ^4.0.2
-    prettier: 3.2.4
+    prettier: 3.2.5
     prisma: ^5.4.1
     remeda: ^1.24.0
     resend: ^2.1.0
@@ -9000,7 +9000,7 @@ __metadata:
     neverthrow: ^6.0.0
     next: 13.4.4
     notistack: ^3.0.1
-    prettier: 3.2.4
+    prettier: 3.2.5
     prisma: ^5.4.1
     react: 18.2.0
     react-device-detect: ^2.2.2
@@ -9286,7 +9286,7 @@ __metadata:
     eslint-plugin-simple-import-sort: ^10.0.0
     jest: ^29.4.0
     jest-expect-message: ^1.1.3
-    prettier: 3.2.4
+    prettier: 3.2.5
     prettier-eslint: ^16.3.0
     ts-jest: ^29.0.5
     ts-node: ^10.9.1
@@ -12189,7 +12189,7 @@ __metadata:
     jest: ^29.4.0
     jest-expect-message: ^1.1.3
     neverthrow: ^6.0.0
-    prettier: 3.2.4
+    prettier: 3.2.5
     remeda: ^1.24.0
     ts-jest: ^29.0.5
     typescript: ^5.2.2
@@ -13213,7 +13213,7 @@ __metadata:
     jest: ^29.4.0
     jest-expect-message: ^1.1.3
     next: 13.4.4
-    prettier: 3.2.4
+    prettier: 3.2.5
     ts-jest: ^29.0.5
     ts-node: ^10.9.1
     tsc-watch: ^6.0.0
@@ -15327,25 +15327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.2.4":
-  version: 3.2.4
-  resolution: "prettier@npm:3.2.4"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 6ec9385a836e0b9bac549e585101c086d1521c31d7b882d5c8bb7d7646da0693da5f31f4fff6dc080710e5e2d34c85e6fb2f8766876b3645c8be2f33b9c3d1a3
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^2.8.3":
-  version: 2.8.3
-  resolution: "prettier@npm:2.8.3"
-  bin:
-    prettier: bin-prettier.js
-  checksum: 92f2ceb522d454370e02082aa74ad27388672f7cee8975028b59517c069fe643bdc73e322675c8faf2ff173d7a626d1a6389f26b474000308e793aa25fff46e5
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^3.0.1":
+"prettier@npm:3.2.5, prettier@npm:^3.0.1, prettier@npm:^3.2.5":
   version: 3.2.5
   resolution: "prettier@npm:3.2.5"
   bin:
@@ -18206,7 +18188,7 @@ __metadata:
     eslint-plugin-simple-import-sort: ^10.0.0
     jest: ^29.4.0
     jest-expect-message: ^1.1.3
-    prettier: 3.2.4
+    prettier: 3.2.5
     ts-jest: ^29.0.5
     ts-node: ^10.9.1
     tsc-watch: ^6.0.0


### PR DESCRIPTION
- consolidate prettier versions
- add empty prettier config file to prevent vscode from providing its own default config which conflicts with linter
