### PR TITLE
corrects resend naming convention

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
       },
     ],
     "@typescript-eslint/no-unsafe-enum-comparison": "error",
+    "@typescript-eslint/no-duplicate-enum-values": "error",
   },
   root: true,
 };

--- a/packages/backend-lib/src/bootstrap.ts
+++ b/packages/backend-lib/src/bootstrap.ts
@@ -1,10 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/common";
 import { randomUUID } from "crypto";
-import {
-  DEBUG_USER_ID1,
-  SUBSCRIPTION_SECRET_NAME,
-} from "isomorphic-lib/src/constants";
+import { DEBUG_USER_ID1, SecretNames } from "isomorphic-lib/src/constants";
 import { v5 as uuidv5 } from "uuid";
 
 import { createWriteKey } from "./auth";
@@ -162,12 +159,12 @@ async function bootstrapPostgres({
       where: {
         workspaceId_name: {
           workspaceId,
-          name: SUBSCRIPTION_SECRET_NAME,
+          name: SecretNames.Subscription,
         },
       },
       create: {
         workspaceId,
-        name: SUBSCRIPTION_SECRET_NAME,
+        name: SecretNames.Subscription,
         value: generateSecureKey(8),
       },
       update: {},

--- a/packages/backend-lib/src/journeys/userWorkflow/activities.ts
+++ b/packages/backend-lib/src/journeys/userWorkflow/activities.ts
@@ -6,10 +6,7 @@ import {
 import { MailDataRequired } from "@sendgrid/mail";
 import escapeHTML from "escape-html";
 import { CHANNEL_IDENTIFIERS } from "isomorphic-lib/src/channels";
-import {
-  FCM_SECRET_NAME,
-  SUBSCRIPTION_SECRET_NAME,
-} from "isomorphic-lib/src/constants";
+import { SecretNames } from "isomorphic-lib/src/constants";
 import { schemaValidateWithErr } from "isomorphic-lib/src/resultHandling/schemaValidation";
 import { assertUnreachable } from "isomorphic-lib/src/typeAssertions";
 import { err, ok, Result } from "neverthrow";
@@ -161,7 +158,7 @@ async function sendWithTracking<C>(
       where: {
         workspaceId_name: {
           workspaceId,
-          name: SUBSCRIPTION_SECRET_NAME,
+          name: SecretNames.Subscription,
         },
       },
     }),
@@ -334,7 +331,7 @@ export async function sendSmsWithPayload(
           identifierKey: CHANNEL_IDENTIFIERS[channel],
           subscriptionGroupId: params.subscriptionGroupId,
           secrets: {
-            [SUBSCRIPTION_SECRET_NAME]: subscriptionSecret,
+            [SecretNames.Subscription]: subscriptionSecret,
           },
         });
 
@@ -453,7 +450,7 @@ export async function sendMobilePushWithPayload(
         where: {
           workspaceId_name: {
             workspaceId,
-            name: FCM_SECRET_NAME,
+            name: SecretNames.Fcm,
           },
         },
       });
@@ -485,7 +482,7 @@ export async function sendMobilePushWithPayload(
           identifierKey: CHANNEL_IDENTIFIERS[channel],
           subscriptionGroupId: params.subscriptionGroupId,
           secrets: {
-            [SUBSCRIPTION_SECRET_NAME]: subscriptionSecret,
+            [SecretNames.Subscription]: subscriptionSecret,
           },
         });
 
@@ -604,7 +601,7 @@ async function sendEmailWithPayload(
           identifierKey: CHANNEL_IDENTIFIERS[channel],
           subscriptionGroupId: params.subscriptionGroupId,
           secrets: {
-            [SUBSCRIPTION_SECRET_NAME]: subscriptionSecret,
+            [SecretNames.Subscription]: subscriptionSecret,
           },
         });
 

--- a/packages/backend-lib/src/liquid.ts
+++ b/packages/backend-lib/src/liquid.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { SUBSCRIPTION_SECRET_NAME } from "isomorphic-lib/src/constants";
+import { SecretNames } from "isomorphic-lib/src/constants";
 import { Liquid } from "liquidjs";
 import MarkdownIt from "markdown-it";
 import mjml2html from "mjml";
@@ -96,7 +96,7 @@ liquidEngine.registerTag("unsubscribe_link", {
     const identifier = assignmentAsString(userProperties, identifierKey);
     const userId = assignmentAsString(userProperties, "id");
 
-    const subscriptionSecret = secrets?.[SUBSCRIPTION_SECRET_NAME];
+    const subscriptionSecret = secrets?.[SecretNames.Subscription];
     if (subscriptionSecret && identifier && userId) {
       const url = generateSubscriptionChangeUrl({
         workspaceId,

--- a/packages/backend-lib/src/messaging.ts
+++ b/packages/backend-lib/src/messaging.ts
@@ -1,6 +1,6 @@
 import { MailDataRequired } from "@sendgrid/mail";
 import { CHANNEL_IDENTIFIERS } from "isomorphic-lib/src/channels";
-import { SUBSCRIPTION_SECRET_NAME } from "isomorphic-lib/src/constants";
+import { SecretNames } from "isomorphic-lib/src/constants";
 import { unwrap } from "isomorphic-lib/src/resultHandling/resultUtils";
 import { schemaValidateWithErr } from "isomorphic-lib/src/resultHandling/schemaValidation";
 import { err, ok, Result } from "neverthrow";
@@ -242,7 +242,7 @@ async function getSendMessageModels({
       where: {
         workspaceId_name: {
           workspaceId,
-          name: SUBSCRIPTION_SECRET_NAME,
+          name: SecretNames.Subscription,
         },
       },
     }),
@@ -528,7 +528,7 @@ export async function sendEmail({
     },
     secrets: subscriptionGroupSecret
       ? {
-          [SUBSCRIPTION_SECRET_NAME]: subscriptionGroupSecret,
+          [SecretNames.Subscription]: subscriptionGroupSecret,
         }
       : undefined,
   });

--- a/packages/backend-lib/src/subscriptionGroups.test.ts
+++ b/packages/backend-lib/src/subscriptionGroups.test.ts
@@ -1,9 +1,6 @@
 import { SubscriptionGroup } from "@prisma/client";
 import { randomUUID } from "crypto";
-import {
-  DEBUG_USER_ID1,
-  SUBSCRIPTION_SECRET_NAME,
-} from "isomorphic-lib/src/constants";
+import { DEBUG_USER_ID1, SecretNames } from "isomorphic-lib/src/constants";
 
 import bootstrap from "./bootstrap";
 import prisma from "./prisma";
@@ -71,7 +68,7 @@ describe("generateSubscriptionChangeUrl", () => {
       where: {
         workspaceId_name: {
           workspaceId,
-          name: SUBSCRIPTION_SECRET_NAME,
+          name: SecretNames.Subscription,
         },
       },
     });

--- a/packages/backend-lib/src/subscriptionGroups.ts
+++ b/packages/backend-lib/src/subscriptionGroups.ts
@@ -1,8 +1,5 @@
 import { Segment, SegmentAssignment, SubscriptionGroup } from "@prisma/client";
-import {
-  SUBSCRIPTION_MANAGEMENT_PAGE,
-  SUBSCRIPTION_SECRET_NAME,
-} from "isomorphic-lib/src/constants";
+import { SecretNames } from "isomorphic-lib/src/constants";
 import { err, ok, Result } from "neverthrow";
 import path from "path";
 import * as R from "remeda";
@@ -247,7 +244,7 @@ export function generateSubscriptionChangeUrl({
       subscriptionChange === SubscriptionChange.Subscribe ? "1" : "0";
   }
   const url = new URL(config().dashboardUrl);
-  url.pathname = path.join("/dashboard", SUBSCRIPTION_MANAGEMENT_PAGE);
+  url.pathname = path.join("/dashboard", SecretNames.Subscription);
   url.search = new URLSearchParams(params).toString();
   const urlString = url.toString();
   logger().debug(
@@ -384,7 +381,7 @@ export async function lookupUserForSubscriptions({
     prisma().secret.findUnique({
       where: {
         workspaceId_name: {
-          name: SUBSCRIPTION_SECRET_NAME,
+          name: SecretNames.Subscription,
           workspaceId,
         },
       },

--- a/packages/dashboard/src/pages/settings.page.tsx
+++ b/packages/dashboard/src/pages/settings.page.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
 import {
   ContentCopyOutlined,
   InfoOutlined,
@@ -31,14 +32,9 @@ import { toSegmentResource } from "backend-lib/src/segments";
 import { subscriptionGroupToResource } from "backend-lib/src/subscriptionGroups";
 import { writeKeyToHeader } from "isomorphic-lib/src/auth";
 import {
-  AMAZONSES_SECRET_NAME,
   EMAIL_PROVIDER_TYPE_TO_SECRET_NAME,
-  POSTMARK_SECRET,
-  RESEND_SECRET,
-  SENDGRID_SECRET,
+  SecretNames,
   SMS_PROVIDER_TYPE_TO_SECRET_NAME,
-  SMTP_SECRET_NAME,
-  TWILIO_SECRET_NAME,
 } from "isomorphic-lib/src/constants";
 import { emailProviderLabel } from "isomorphic-lib/src/email";
 import { unwrap } from "isomorphic-lib/src/resultHandling/resultUtils";
@@ -615,30 +611,32 @@ function SendGridConfig() {
                   id: "sendgrid-api-key",
                   type: "secret",
                   fieldProps: {
-                    name: SENDGRID_SECRET,
+                    name: SecretNames.Sendgrid,
                     secretKey: "apiKey",
                     label: "Sendgrid API Key",
                     helperText:
                       "API key, used internally by Dittofeed to send emails via sendgrid.",
                     type: EmailProviderType.Sendgrid,
                     saved:
-                      secretAvailability.find((s) => s.name === SENDGRID_SECRET)
-                        ?.configValue?.apiKey ?? false,
+                      secretAvailability.find(
+                        (s) => s.name === SecretNames.Sendgrid,
+                      )?.configValue?.apiKey ?? false,
                   },
                 },
                 {
                   id: "sendgrid-webhook-key",
                   type: "secret",
                   fieldProps: {
-                    name: SENDGRID_SECRET,
+                    name: SecretNames.Sendgrid,
                     secretKey: "webhookKey",
                     label: "Webhook Key",
                     helperText:
                       "Sendgrid webhook verification key, used to authenticate sendgrid webhook requests.",
                     type: EmailProviderType.Sendgrid,
                     saved:
-                      secretAvailability.find((s) => s.name === SENDGRID_SECRET)
-                        ?.configValue?.webhookKey ?? false,
+                      secretAvailability.find(
+                        (s) => s.name === SecretNames.Sendgrid,
+                      )?.configValue?.webhookKey ?? false,
                   },
                 },
               ],
@@ -667,14 +665,14 @@ function AmazonSesConfig() {
                   id: "amazonses-access-key-id",
                   type: "secret",
                   fieldProps: {
-                    name: AMAZONSES_SECRET_NAME,
+                    name: SecretNames.AmazonSes,
                     secretKey: "accessKeyId",
                     label: "Access Key Id",
                     helperText: "IAM user access key",
                     type: EmailProviderType.AmazonSes,
                     saved:
                       secretAvailability.find(
-                        (s) => s.name === AMAZONSES_SECRET_NAME,
+                        (s) => s.name === SecretNames.AmazonSes,
                       )?.configValue?.accessKeyId ?? false,
                   },
                 },
@@ -682,14 +680,14 @@ function AmazonSesConfig() {
                   id: "amazonses-secret-access-key",
                   type: "secret",
                   fieldProps: {
-                    name: AMAZONSES_SECRET_NAME,
+                    name: SecretNames.AmazonSes,
                     secretKey: "secretAccessKey",
                     label: "Secret Access Key",
                     helperText: "Secret access key for IAM user.",
                     type: EmailProviderType.AmazonSes,
                     saved:
                       secretAvailability.find(
-                        (s) => s.name === AMAZONSES_SECRET_NAME,
+                        (s) => s.name === SecretNames.AmazonSes,
                       )?.configValue?.secretAccessKey ?? false,
                   },
                 },
@@ -697,14 +695,14 @@ function AmazonSesConfig() {
                   id: "amazonses-region",
                   type: "secret",
                   fieldProps: {
-                    name: AMAZONSES_SECRET_NAME,
+                    name: SecretNames.AmazonSes,
                     secretKey: "region",
                     label: "AWS Region",
                     helperText: "The AWS region to route requests to.",
                     type: EmailProviderType.AmazonSes,
                     saved:
                       secretAvailability.find(
-                        (s) => s.name === AMAZONSES_SECRET_NAME,
+                        (s) => s.name === SecretNames.AmazonSes,
                       )?.configValue?.region ?? false,
                   },
                 },
@@ -734,30 +732,32 @@ function ResendConfig() {
                   id: "resend-api-key",
                   type: "secret",
                   fieldProps: {
-                    name: RESEND_SECRET,
+                    name: SecretNames.Resend,
                     secretKey: "apiKey",
                     label: "Resend API Key",
                     helperText:
                       "API key, used internally by Dittofeed to send emails via resend.",
                     type: EmailProviderType.Resend,
                     saved:
-                      secretAvailability.find((s) => s.name === RESEND_SECRET)
-                        ?.configValue?.apiKey ?? false,
+                      secretAvailability.find(
+                        (s) => s.name === SecretNames.Resend,
+                      )?.configValue?.apiKey ?? false,
                   },
                 },
                 {
                   id: "resend-webhook-key",
                   type: "secret",
                   fieldProps: {
-                    name: RESEND_SECRET,
+                    name: SecretNames.Resend,
                     secretKey: "webhookKey",
                     label: "Webhook Key",
                     helperText:
                       "Resend webhook verification key, used to authenticate resend webhook requests.",
                     type: EmailProviderType.Resend,
                     saved:
-                      secretAvailability.find((s) => s.name === RESEND_SECRET)
-                        ?.configValue?.webhookKey ?? false,
+                      secretAvailability.find(
+                        (s) => s.name === SecretNames.Resend,
+                      )?.configValue?.webhookKey ?? false,
                   },
                 },
               ],
@@ -786,30 +786,32 @@ function PostMarkConfig() {
                   id: "postmark-api-key",
                   type: "secret",
                   fieldProps: {
-                    name: POSTMARK_SECRET,
+                    name: SecretNames.Postmark,
                     secretKey: "apiKey",
                     label: "API Key",
                     helperText:
                       "API key, used by Dittofeed to send emails via Postmark.",
                     type: EmailProviderType.PostMark,
                     saved:
-                      secretAvailability.find((s) => s.name === POSTMARK_SECRET)
-                        ?.configValue?.apiKey ?? false,
+                      secretAvailability.find(
+                        (s) => s.name === SecretNames.Postmark,
+                      )?.configValue?.apiKey ?? false,
                   },
                 },
                 {
                   id: "postmark-webhook-key",
                   type: "secret",
                   fieldProps: {
-                    name: POSTMARK_SECRET,
+                    name: SecretNames.Postmark,
                     secretKey: "webhookKey",
                     label: "Webhook Key",
                     helperText:
                       "Auth header value (x-postmark-secret), used to authenticate PostMark webhook requests. Use a secure random string generator.",
                     type: EmailProviderType.PostMark,
                     saved:
-                      secretAvailability.find((s) => s.name === POSTMARK_SECRET)
-                        ?.configValue?.webhookKey ?? false,
+                      secretAvailability.find(
+                        (s) => s.name === SecretNames.Postmark,
+                      )?.configValue?.webhookKey ?? false,
                   },
                 },
               ],
@@ -854,13 +856,13 @@ function SmtpConfig() {
     id: `smtp-${field.key}`,
     type: "secret",
     fieldProps: {
-      name: SMTP_SECRET_NAME,
+      name: SecretNames.Smtp,
       secretKey: field.key,
       label: field.label,
       helperText: field.helperText,
       type: EmailProviderType.Smtp,
       saved:
-        secretAvailability.find((s) => s.name === SMTP_SECRET_NAME)
+        secretAvailability.find((s) => s.name === SecretNames.Smtp)
           ?.configValue?.[field.key] ?? false,
     },
   }));
@@ -1187,14 +1189,14 @@ function Twilios() {
                   id: "twilio-account-sid",
                   type: "secret",
                   fieldProps: {
-                    name: TWILIO_SECRET_NAME,
+                    name: SecretNames.Twilio,
                     secretKey: "accountSid",
                     label: "Account SID",
                     helperText: "Twilio Account SID",
                     type: SmsProviderType.Twilio,
                     saved:
                       secretAvailability.find(
-                        (s) => s.name === TWILIO_SECRET_NAME,
+                        (s) => s.name === SecretNames.Twilio,
                       )?.configValue?.accountSid ?? false,
                   },
                 },
@@ -1202,14 +1204,14 @@ function Twilios() {
                   id: "twilio-messaging-service-sid",
                   type: "secret",
                   fieldProps: {
-                    name: TWILIO_SECRET_NAME,
+                    name: SecretNames.Twilio,
                     secretKey: "messagingServiceSid",
                     label: "Messaging Service SID",
                     helperText: "Twilio messaging service SID",
                     type: SmsProviderType.Twilio,
                     saved:
                       secretAvailability.find(
-                        (s) => s.name === TWILIO_SECRET_NAME,
+                        (s) => s.name === SecretNames.Twilio,
                       )?.configValue?.messagingServiceSid ?? false,
                   },
                 },
@@ -1217,7 +1219,7 @@ function Twilios() {
                   id: "twilio-auth-token",
                   type: "secret",
                   fieldProps: {
-                    name: TWILIO_SECRET_NAME,
+                    name: SecretNames.Twilio,
                     secretKey: "authToken",
                     label: "Twilio Auth Token",
                     helperText:
@@ -1225,7 +1227,7 @@ function Twilios() {
                     type: SmsProviderType.Twilio,
                     saved:
                       secretAvailability.find(
-                        (s) => s.name === TWILIO_SECRET_NAME,
+                        (s) => s.name === SecretNames.Twilio,
                       )?.configValue?.authToken ?? false,
                   },
                 },

--- a/packages/isomorphic-lib/src/constants.ts
+++ b/packages/isomorphic-lib/src/constants.ts
@@ -15,18 +15,20 @@ export const EMAIL_NOT_VERIFIED_PAGE = "/waiting-room" as const;
 export const SUBSCRIPTION_MANAGEMENT_PAGE =
   "/public/subscription-management" as const;
 export const DEBUG_USER_ID1 = "1b9858de-907d-493f-a067-b3c8effecb0b" as const;
-export const SUBSCRIPTION_SECRET_NAME = "subscription-key" as const;
-export const TWILIO_SECRET_NAME = "twilio-key" as const;
-export const SENDGRID_WEBHOOK_SECRET_NAME = "sendgrid-webhook" as const;
-export const SENDGRID_SECRET = "sendgrid" as const;
-export const AMAZONSES_SECRET_NAME = "amazonses" as const;
-export const RESEND_SECRET = "sendgrid" as const;
-export const POSTMARK_SECRET = "postmark" as const;
-export const FCM_SECRET_NAME = "fcm-key" as const;
-export const SMTP_SECRET_NAME = "smtp" as const;
+
+export enum SecretNames {
+  Twilio = "twilio-key",
+  Sendgrid = "sendgrid",
+  AmazonSes = "amazonses",
+  Resend = "resend",
+  Postmark = "postmark",
+  Fcm = "fcm-key",
+  Smtp = "smtp",
+  Subscription = "subscription-key",
+}
 export const SMS_PROVIDER_TYPE_TO_SECRET_NAME: Record<SmsProviderType, string> =
   {
-    [SmsProviderType.Twilio]: TWILIO_SECRET_NAME,
+    [SmsProviderType.Twilio]: SecretNames.Twilio,
     [SmsProviderType.Test]: "",
   };
 
@@ -34,11 +36,11 @@ export const EMAIL_PROVIDER_TYPE_TO_SECRET_NAME: Record<
   EmailProviderType,
   string
 > = {
-  [EmailProviderType.Sendgrid]: SENDGRID_SECRET,
-  [EmailProviderType.AmazonSes]: AMAZONSES_SECRET_NAME,
-  [EmailProviderType.Smtp]: SMTP_SECRET_NAME,
-  [EmailProviderType.Resend]: RESEND_SECRET,
-  [EmailProviderType.PostMark]: POSTMARK_SECRET,
+  [EmailProviderType.Sendgrid]: SecretNames.Sendgrid,
+  [EmailProviderType.AmazonSes]: SecretNames.AmazonSes,
+  [EmailProviderType.Smtp]: SecretNames.Smtp,
+  [EmailProviderType.Resend]: SecretNames.Resend,
+  [EmailProviderType.PostMark]: SecretNames.Postmark,
   [EmailProviderType.Test]: "",
 };
 


### PR DESCRIPTION
- resend secret had been using sendgrid name, causing clash
- includes script for correcting values