### PR TITLE
render.yaml improvements

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -31,10 +31,9 @@ envVarGroups:
 services:
   - type: web
     name: dittofeed-lite
-    env: docker
+    env: image
     autoDeploy: false
-    image:
-      name: dittofeed/dittofeed-lite:v0.12.1
+    image: dittofeed/dittofeed-lite:v0.12.1
     # Setting Node.js max-old-space-size to 412 MB.
     # This is calculated as follows: Total RAM (512 MB) - Buffer (100 MB) -
     # Memory for other processes (100 MB).

--- a/render.yaml
+++ b/render.yaml
@@ -33,12 +33,12 @@ services:
     name: dittofeed-lite
     env: docker
     autoDeploy: false
-    dockerfilePath: ./packages/lite/Dockerfile
-    dockerContext: .
-    # Setting Node.js max-old-space-size to 312 MB.
-    # This is calculated as follows: Total RAM (512 MB) - Buffer (200 MB) -
+    image:
+      name: dittofeed/dittofeed-lite:v0.12.1
+    # Setting Node.js max-old-space-size to 412 MB.
+    # This is calculated as follows: Total RAM (512 MB) - Buffer (100 MB) -
     # Memory for other processes (100 MB).
-    dockerCommand: node --max-old-space-size=212 packages/lite/dist/scripts/startLite.js --workspace-name=$WORKSPACE_NAME
+    dockerCommand: node --max-old-space-size=412 packages/lite/dist/scripts/startLite.js --workspace-name=$WORKSPACE_NAME
     envVars:
       - fromGroup: backend-app-env
       - fromGroup: clickhouse-credentials

--- a/render.yaml
+++ b/render.yaml
@@ -31,9 +31,10 @@ envVarGroups:
 services:
   - type: web
     name: dittofeed-lite
-    env: image
+    runtime: image
     autoDeploy: false
-    image: dittofeed/dittofeed-lite:v0.12.1
+    image:
+      url: "docker.io/dittofeed/dittofeed-lite:v0.12.1"
     # Setting Node.js max-old-space-size to 412 MB.
     # This is calculated as follows: Total RAM (512 MB) - Buffer (100 MB) -
     # Memory for other processes (100 MB).


### PR DESCRIPTION
- use pre-built image
- increase node memory limit to 412mb