### PR TITLE
#816 Add default form address override feature

### DIFF
--- a/packages/dashboard/src/components/modal.tsx
+++ b/packages/dashboard/src/components/modal.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { Modal, Box, Typography, Button } from "@mui/material";
+
+ interface ModalProps<Data> {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description?: string;
+  data: Data[];
+  onClick: () => void;
+  renderContent: (item: Data, index: number) => React.ReactNode;
+  overrideButtonLabel?: string;
+}
+
+const ModalComponent = <Data,>({
+  open,
+  onClose,
+  title,
+  description,
+  data,
+  onClick,
+  renderContent,
+  overrideButtonLabel = "Override",
+}: ModalProps<Data>) => {
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      aria-labelledby="modal-title"
+      aria-describedby="modal-description"
+    >
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          bgcolor: "white",
+          boxShadow: 24,
+          p: 4,
+          maxWidth: 800,
+          minWidth: 400,
+        }}
+      >
+        <Typography
+          variant="h2"
+          fontWeight={300}
+          sx={{ fontSize: 20, marginBottom: 1.5 }}
+        >
+
+          {title}
+        </Typography>
+
+        {description && (
+          <Typography variant="subtitle1" fontWeight="normal" sx={{ opacity: 0.6 }}>
+            {description}
+          </Typography>
+        )}
+        <Box>
+          {data.map((item, index) => (
+            <React.Fragment key={index}>
+              {renderContent(item, index)}
+            </React.Fragment>
+          ))}
+        </Box>
+        <Box sx={{ mt: 4, display: "flex", justifyContent: "flex-end" }}>
+          <Button variant="contained" onClick={onClick}>
+            {overrideButtonLabel}
+          </Button>
+          <Button variant="contained" onClick={onClose} sx={{ ml: 2 }}>
+            Close & save
+          </Button>
+        </Box>
+      </Box>
+    </Modal>
+  );
+};
+
+export default ModalComponent;

--- a/packages/dashboard/src/lib/types.ts
+++ b/packages/dashboard/src/lib/types.ts
@@ -154,6 +154,7 @@ export type AppState = {
   defaultEmailProvider: DefaultEmailProviderResource | null;
   emailProviders: PersistedEmailProvider[];
   defaultSmsProvider: DefaultSmsProviderResource | null;
+  messageTemplateEmailType : MessageTemplateResource[];
   smsProviders: PersistedSmsProvider[];
   dataSourceConfigurations: RequestStatus<
     DataSourceConfigurationResource[],

--- a/packages/isomorphic-lib/src/types.ts
+++ b/packages/isomorphic-lib/src/types.ts
@@ -1214,6 +1214,7 @@ export const DefaultEmailProviderResource = Type.Object({
   workspaceId: Type.String(),
   emailProviderId: Type.String(),
   fromAddress: Nullable(Type.String()),
+  templateIds: Type.Optional(Type.Array(Type.String()))
 });
 
 export type DefaultEmailProviderResource = Static<


### PR DESCRIPTION
This pull request adds the "Override" feature to the email provider settings modal. 

- Added functionality to override default email provider settings with custom settings for specific templates.
- Enhanced the modal component to display a list of templates with different 'From' addresses.
- Added a button to allow users to override the default settings for individual templates.