### PR TITLE
fix: align controls in user segments table

### DIFF
--- a/packages/dashboard/src/components/resourceList.tsx
+++ b/packages/dashboard/src/components/resourceList.tsx
@@ -82,7 +82,7 @@ export function ResourceListContainer({
         <Typography sx={{ padding: 1 }} variant="h5">
           {title}
         </Typography>
-        <Stack direction="row" spacing={1}>
+        <Stack direction="row" spacing={1} alignItems="center">
           {controls}
           <Tooltip title="create new" placement="right" arrow>
             <IconButton


### PR DESCRIPTION
small change in user segments table controls

before: 
![image](https://github.com/dittofeed/dittofeed/assets/47697586/273f9be1-8c84-490b-9956-b4885b98a3ba)

after:
![image](https://github.com/dittofeed/dittofeed/assets/47697586/ac643589-58ae-411e-9cf0-31e3f4abf5a1)
