### PR TITLE
remove join from processed query

### DIFF
--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
@@ -4454,6 +4454,8 @@ describe("computeProperties", () => {
     },
     {
       description: "when a performed segment has a within condition",
+      // FIXME
+      only: true,
       userProperties: [
         {
           name: "id",

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
@@ -4454,6 +4454,8 @@ describe("computeProperties", () => {
     },
     {
       description: "when a performed segment has a within condition",
+      // FIXME
+      only: true,
       userProperties: [
         {
           name: "id",
@@ -4606,8 +4608,18 @@ describe("computeProperties", () => {
         },
         {
           type: EventsStepType.Assert,
+          // FIXME
           description:
             "then after resubmitting the event the user enters the segment a second time",
+          states: [
+            {
+              userId: "user-1",
+              type: "segment",
+              nodeId: "1",
+              uniqueCount: 3,
+              name: "recentlyPerformed",
+            },
+          ],
           users: [
             {
               id: "user-1",
@@ -5171,6 +5183,12 @@ describe("computeProperties", () => {
               events.push(event);
             }
           }
+          logger().debug(
+            {
+              events,
+            },
+            "submitEvents step",
+          );
           await submitBatch({
             workspaceId,
             data: events,
@@ -5208,6 +5226,13 @@ describe("computeProperties", () => {
           break;
         }
         case EventsStepType.ComputeProperties:
+          logger().debug(
+            {
+              segments,
+              userProperties,
+            },
+            "computeProperties step",
+          );
           await computeState({
             workspaceId,
             segments,
@@ -5231,6 +5256,12 @@ describe("computeProperties", () => {
           break;
         case EventsStepType.Sleep:
           now += step.timeMs;
+          logger().debug(
+            {
+              now,
+            },
+            "sleep step",
+          );
           break;
         case EventsStepType.Assert: {
           const usersAssertions =

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
@@ -4454,8 +4454,6 @@ describe("computeProperties", () => {
     },
     {
       description: "when a performed segment has a within condition",
-      // FIXME
-      only: true,
       userProperties: [
         {
           name: "id",
@@ -4608,7 +4606,6 @@ describe("computeProperties", () => {
         },
         {
           type: EventsStepType.Assert,
-          // FIXME
           description:
             "then after resubmitting the event the user enters the segment a second time",
           states: [

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.test.ts
@@ -4454,8 +4454,6 @@ describe("computeProperties", () => {
     },
     {
       description: "when a performed segment has a within condition",
-      // FIXME
-      only: true,
       userProperties: [
         {
           name: "id",

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
@@ -3167,6 +3167,7 @@ function buildProcessAssignmentsQuery({
         existingNonEmptyCondition = `pcp.user_property_value != '""' AND pcp.user_property_value != ''`;
         break;
     }
+    // FIXME do argmax in processed
     return `
       SELECT
         cpa.workspace_id,
@@ -3262,6 +3263,7 @@ function buildProcessAssignmentsQuery({
     ) cpa
     WHERE
       ${nonEmptyCondition}
+      -- FIXME
       AND (
         cpa.workspace_id,
         cpa.type,

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
@@ -3362,8 +3362,6 @@ type AssignmentProcessorParams = (
 class AssignmentProcessor {
   private pageSize;
 
-  // private page = 0;
-
   private params: AssignmentProcessorParams;
 
   constructor(params: AssignmentProcessorParams) {
@@ -3381,77 +3379,19 @@ class AssignmentProcessor {
         "computedPropertyVersion",
         this.params.computedPropertyVersion,
       );
-      const queryIds: string[] = [];
 
-      // let retrieved = this.pageSize;
-      // while (retrieved >= this.pageSize) {
-      //   const qb = new ClickHouseQueryBuilder();
-      //   // Applies a concurrency limit to the query
+      const [
+        { queryIds: queryIdsNonEmpty, page: pageNonEmpty },
+        { queryIds: queryIdsEmpty, page: pageEmpty },
+      ] = await Promise.all([
+        this.paginateProcessAssignments(false),
+        this.paginateProcessAssignments(true),
+      ]);
 
-      //   retrieved = await withSpan(
-      //     { name: "process-assignments-query-page" },
-      //     async (pageSpan) => {
-      //       const offset = this.page * this.pageSize;
-      //       const { journeys, ...processAssignmentsParams } = this.params;
-      //       const pageQueryId = getChCompatibleUuid();
-      //       queryIds.push(pageQueryId);
-
-      //       pageSpan.setAttribute("workspaceId", this.params.workspaceId);
-      //       pageSpan.setAttribute(
-      //         "computedPropertyId",
-      //         this.params.computedPropertyId,
-      //       );
-      //       pageSpan.setAttribute("type", this.params.type);
-      //       pageSpan.setAttribute(
-      //         "processedForType",
-      //         this.params.processedForType,
-      //       );
-      //       pageSpan.setAttribute("page", this.page);
-      //       pageSpan.setAttribute("pageSize", this.pageSize);
-      //       pageSpan.setAttribute("queryId", pageQueryId);
-      //       pageSpan.setAttribute(
-      //         "computedPropertyVersion",
-      //         this.params.computedPropertyVersion,
-      //       );
-
-      //       return readLimit()(async () => {
-      //         const query = buildProcessAssignmentsQuery({
-      //           ...processAssignmentsParams,
-      //           limit: this.pageSize,
-      //           offset,
-      //           qb,
-      //         });
-      //         // Both paginates through the assignments, and streams results
-      //         // within a given page
-      //         const pageRetrieved = await streamProcessAssignmentsPage({
-      //           query,
-      //           workspaceId: this.params.workspaceId,
-      //           qb,
-      //           journeys,
-      //           queryId: pageQueryId,
-      //         });
-      //         pageSpan.setAttribute("retrieved", pageRetrieved);
-      //         return pageRetrieved;
-      //       });
-      //     },
-      //   );
-      //   logger().info(
-      //     {
-      //       workspaceId: this.params.workspaceId,
-      //       computedPropertyId: this.params.computedPropertyId,
-      //       type: this.params.type,
-      //       processedForType: this.params.processedForType,
-      //       retrieved,
-      //     },
-      //     "retrieved assignments",
-      //   );
-      //   this.page += 1;
-      // }
-
-      // FIXME
-      span.setAttribute("processedPagesEmpty", 0);
-      span.setAttribute("processedPagesNonEmpty", 0);
-      span.setAttribute("queryIds", queryIds);
+      span.setAttribute("processedPagesEmpty", pageEmpty);
+      span.setAttribute("processedPagesNonEmpty", pageNonEmpty);
+      span.setAttribute("emptyQueryIds", queryIdsEmpty);
+      span.setAttribute("nonEmptyQueryIds", queryIdsNonEmpty);
     });
   }
 

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
@@ -3168,7 +3168,6 @@ function buildProcessAssignmentsQuery({
         existingNonEmptyCondition = `inner.latest_user_property_value != '""' AND inner.latest_user_property_value != ''`;
         break;
     }
-    // FIXME do argmax in processed
     return `
       SELECT
         cpa.workspace_id,

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
@@ -3380,13 +3380,10 @@ class AssignmentProcessor {
         this.params.computedPropertyVersion,
       );
 
-      const [
-        { queryIds: queryIdsNonEmpty, page: pageNonEmpty },
-        { queryIds: queryIdsEmpty, page: pageEmpty },
-      ] = await Promise.all([
-        this.paginateProcessAssignments(false),
-        this.paginateProcessAssignments(true),
-      ]);
+      const { queryIds: queryIdsNonEmpty, page: pageNonEmpty } =
+        await this.paginateProcessAssignments(false);
+      const { queryIds: queryIdsEmpty, page: pageEmpty } =
+        await this.paginateProcessAssignments(true);
 
       span.setAttribute("processedPagesEmpty", pageEmpty);
       span.setAttribute("processedPagesNonEmpty", pageNonEmpty);

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-await-in-loop */
+/* eslint-disable @typescript-eslint/no-loop-func,no-await-in-loop */
 
 import { toJsonPathParam } from "isomorphic-lib/src/jsonPath";
 import { schemaValidateWithErr } from "isomorphic-lib/src/resultHandling/schemaValidation";
@@ -3082,7 +3082,6 @@ interface BaseProcessAssignmentsQueryArgs {
   computedPropertyId: string;
   qb: ClickHouseQueryBuilder;
   computedPropertyVersion: string;
-  now: number;
   periodByComputedPropertyId: PeriodByComputedPropertyId;
 }
 
@@ -3116,13 +3115,14 @@ function buildProcessAssignmentsQuery({
   qb,
   periodByComputedPropertyId,
   computedPropertyVersion,
-  now,
   limit,
   offset,
+  forEmpty,
   ...rest
 }: ProcessAssignmentsQueryArgs & {
   limit: number;
   offset: number;
+  forEmpty: boolean;
 }): string {
   const workspaceIdParam = qb.addQueryValue(workspaceId, "String");
   const computedPropertyIdParam = qb.addQueryValue(
@@ -3137,13 +3137,13 @@ function buildProcessAssignmentsQuery({
     "String",
   );
   const typeParam = qb.addQueryValue(type, "String");
-  let typeCondition: string;
+  let nonEmptyCondition: string;
   switch (type) {
     case "segment":
-      typeCondition = "cpa.latest_segment_value = true";
+      nonEmptyCondition = "cpa.latest_segment_value = true";
       break;
     case "user_property":
-      typeCondition = `cpa.latest_user_property_value != '""' AND cpa.latest_user_property_value != ''`;
+      nonEmptyCondition = `cpa.latest_user_property_value != '""' AND cpa.latest_user_property_value != ''`;
       break;
   }
 
@@ -3156,23 +3156,80 @@ function buildProcessAssignmentsQuery({
     periodBound && periodBound > 0
       ? `and assigned_at >= toDateTime64(${periodBound / 1000}, 3)`
       : "";
-  const nowSeconds = now / 1000;
 
-  /**
-   * This query is a bit complicated, so here's a breakdown of what it does:
-   *
-   * 1. It reads all the computed property assignments for the workspace.
-   * 2. It joins the computed property assignments with the processed computed
-   * properties table to filter out assignments that have already been
-   * processed.
-   * 3. It filters out "empty assignments" (assignments where the user property
-   * value is empty, or the segment value is false) if the property has not
-   * already been assigned.
-   * 4. It filters out false segment assignments to journeys.
-   */
-  // TODO remove left join
-  const query = `
-   SELECT
+  if (forEmpty) {
+    let existingNonEmptyCondition: string;
+    switch (type) {
+      case "segment":
+        existingNonEmptyCondition = "pcp.latest_segment_value = true";
+        break;
+      case "user_property":
+        existingNonEmptyCondition = `pcp.latest_user_property_value != '""' AND pcp.latest_user_property_value != ''`;
+        break;
+    }
+    return `
+      SELECT
+        cpa.workspace_id,
+        cpa.type,
+        cpa.computed_property_id,
+        cpa.user_id,
+        cpa.latest_segment_value,
+        cpa.latest_user_property_value,
+        cpa.max_assigned_at,
+        ${processedForParam} as processed_for,
+        ${processedForTypeParam} as processed_for_type
+      FROM (
+        SELECT
+            workspace_id,
+            type,
+            computed_property_id,
+            user_id,
+            max(assigned_at) max_assigned_at,
+            argMax(segment_value, assigned_at) latest_segment_value,
+            argMax(user_property_value, assigned_at) latest_user_property_value
+        FROM computed_property_assignments_v2
+        WHERE
+          workspace_id = ${workspaceIdParam}
+          AND type = ${typeParam}
+          AND computed_property_id = ${computedPropertyIdParam}
+          ${lowerBoundClause}
+        GROUP BY
+            workspace_id,
+            type,
+            computed_property_id,
+            user_id
+      ) cpa
+      WHERE
+        NOT (${nonEmptyCondition})
+        AND (
+          cpa.workspace_id,
+          cpa.type,
+          cpa.computed_property_id,
+          cpa.user_id,
+          ${processedForParam},
+          ${processedForTypeParam}
+        ) IN (
+          SELECT
+            workspace_id,
+            type,
+            computed_property_id,
+            user_id,
+            processed_for,
+            processed_for_type
+          FROM processed_computed_properties_v2 as pcp
+          WHERE
+            workspace_id = ${workspaceIdParam}
+            AND type = ${typeParam}
+            AND computed_property_id = ${computedPropertyIdParam}
+            AND processed_for_type = ${processedForTypeParam}
+            AND processed_for = ${processedForParam}
+            AND ${existingNonEmptyCondition}
+        )
+      LIMIT ${offset}, ${limit}
+    `;
+  }
+  return `
+    SELECT
       cpa.workspace_id,
       cpa.type,
       cpa.computed_property_id,
@@ -3203,39 +3260,37 @@ function buildProcessAssignmentsQuery({
           computed_property_id,
           user_id
     ) cpa
-    LEFT JOIN (
-      SELECT
-        user_id,
-        argMax(segment_value, processed_at) segment_value,
-        argMax(user_property_value, processed_at) user_property_value
-      FROM processed_computed_properties_v2
-      WHERE
-        workspace_id = ${workspaceIdParam}
-        AND type = ${typeParam}
-        AND computed_property_id = ${computedPropertyIdParam}
-        AND processed_for_type = ${processedForTypeParam}
-        AND processed_for = ${processedForParam}
-      GROUP BY
-        workspace_id,
-        computed_property_id,
-        user_id,
-        processed_for_type,
-        processed_for
-    ) pcp
-    ON cpa.user_id = pcp.user_id
-    WHERE (
-      cpa.latest_user_property_value != pcp.user_property_value
-      OR cpa.latest_segment_value != pcp.segment_value
-    )
-    AND (
-        (${typeCondition})
-        OR (
-            pcp.user_id != ''
-        )
-    )
+    WHERE
+      ${nonEmptyCondition}
+      AND (
+        cpa.workspace_id,
+        cpa.type,
+        cpa.computed_property_id,
+        cpa.user_id,
+        cpa.latest_segment_value,
+        cpa.latest_user_property_value,
+        ${processedForParam},
+        ${processedForTypeParam}
+      ) NOT IN (
+        SELECT
+          workspace_id,
+          type,
+          computed_property_id,
+          user_id,
+          segment_value,
+          user_property_value,
+          processed_for,
+          processed_for_type
+        FROM processed_computed_properties_v2
+        WHERE
+          workspace_id = ${workspaceIdParam}
+          AND type = ${typeParam}
+          AND computed_property_id = ${computedPropertyIdParam}
+          AND processed_for_type = ${processedForTypeParam}
+          AND processed_for = ${processedForParam}
+      )
     LIMIT ${offset}, ${limit}
   `;
-  return query;
 }
 
 async function streamProcessAssignmentsPage({
@@ -3307,7 +3362,7 @@ type AssignmentProcessorParams = (
 class AssignmentProcessor {
   private pageSize;
 
-  private page = 0;
+  // private page = 0;
 
   private params: AssignmentProcessorParams;
 
@@ -3328,75 +3383,244 @@ class AssignmentProcessor {
       );
       const queryIds: string[] = [];
 
-      let retrieved = this.pageSize;
-      while (retrieved >= this.pageSize) {
-        const qb = new ClickHouseQueryBuilder();
-        // Applies a concurrency limit to the query
+      // let retrieved = this.pageSize;
+      // while (retrieved >= this.pageSize) {
+      //   const qb = new ClickHouseQueryBuilder();
+      //   // Applies a concurrency limit to the query
 
-        retrieved = await withSpan(
-          { name: "process-assignments-query-page" },
-          async (pageSpan) => {
-            const offset = this.page * this.pageSize;
-            const { journeys, ...processAssignmentsParams } = this.params;
-            const pageQueryId = getChCompatibleUuid();
-            queryIds.push(pageQueryId);
+      //   retrieved = await withSpan(
+      //     { name: "process-assignments-query-page" },
+      //     async (pageSpan) => {
+      //       const offset = this.page * this.pageSize;
+      //       const { journeys, ...processAssignmentsParams } = this.params;
+      //       const pageQueryId = getChCompatibleUuid();
+      //       queryIds.push(pageQueryId);
 
-            pageSpan.setAttribute("workspaceId", this.params.workspaceId);
-            pageSpan.setAttribute(
-              "computedPropertyId",
-              this.params.computedPropertyId,
-            );
-            pageSpan.setAttribute("type", this.params.type);
-            pageSpan.setAttribute(
-              "processedForType",
-              this.params.processedForType,
-            );
-            pageSpan.setAttribute("page", this.page);
-            pageSpan.setAttribute("pageSize", this.pageSize);
-            pageSpan.setAttribute("queryId", pageQueryId);
-            pageSpan.setAttribute(
-              "computedPropertyVersion",
-              this.params.computedPropertyVersion,
-            );
+      //       pageSpan.setAttribute("workspaceId", this.params.workspaceId);
+      //       pageSpan.setAttribute(
+      //         "computedPropertyId",
+      //         this.params.computedPropertyId,
+      //       );
+      //       pageSpan.setAttribute("type", this.params.type);
+      //       pageSpan.setAttribute(
+      //         "processedForType",
+      //         this.params.processedForType,
+      //       );
+      //       pageSpan.setAttribute("page", this.page);
+      //       pageSpan.setAttribute("pageSize", this.pageSize);
+      //       pageSpan.setAttribute("queryId", pageQueryId);
+      //       pageSpan.setAttribute(
+      //         "computedPropertyVersion",
+      //         this.params.computedPropertyVersion,
+      //       );
 
-            return readLimit()(async () => {
-              const query = buildProcessAssignmentsQuery({
-                ...processAssignmentsParams,
-                limit: this.pageSize,
-                offset,
-                qb,
-              });
-              // Both paginates through the assignments, and streams results
-              // within a given page
-              const pageRetrieved = await streamProcessAssignmentsPage({
-                query,
-                workspaceId: this.params.workspaceId,
-                qb,
-                journeys,
-                queryId: pageQueryId,
-              });
-              pageSpan.setAttribute("retrieved", pageRetrieved);
-              return pageRetrieved;
-            });
-          },
-        );
-        logger().info(
-          {
-            workspaceId: this.params.workspaceId,
-            computedPropertyId: this.params.computedPropertyId,
-            type: this.params.type,
-            processedForType: this.params.processedForType,
-            retrieved,
-          },
-          "retrieved assignments",
-        );
-        this.page += 1;
-      }
+      //       return readLimit()(async () => {
+      //         const query = buildProcessAssignmentsQuery({
+      //           ...processAssignmentsParams,
+      //           limit: this.pageSize,
+      //           offset,
+      //           qb,
+      //         });
+      //         // Both paginates through the assignments, and streams results
+      //         // within a given page
+      //         const pageRetrieved = await streamProcessAssignmentsPage({
+      //           query,
+      //           workspaceId: this.params.workspaceId,
+      //           qb,
+      //           journeys,
+      //           queryId: pageQueryId,
+      //         });
+      //         pageSpan.setAttribute("retrieved", pageRetrieved);
+      //         return pageRetrieved;
+      //       });
+      //     },
+      //   );
+      //   logger().info(
+      //     {
+      //       workspaceId: this.params.workspaceId,
+      //       computedPropertyId: this.params.computedPropertyId,
+      //       type: this.params.type,
+      //       processedForType: this.params.processedForType,
+      //       retrieved,
+      //     },
+      //     "retrieved assignments",
+      //   );
+      //   this.page += 1;
+      // }
 
-      span.setAttribute("processedPages", this.page);
+      // FIXME
+      span.setAttribute("processedPagesEmpty", 0);
+      span.setAttribute("processedPagesNonEmpty", 0);
       span.setAttribute("queryIds", queryIds);
     });
   }
+
+  async paginateProcessAssignments(forEmpty: boolean): Promise<{
+    queryIds: string[];
+    page: number;
+  }> {
+    let retrieved = this.pageSize;
+    let page = 0;
+    const queryIds: string[] = [];
+    // We don't need to process empty assignments for journeys which only need
+    // to receive true signals.
+    if (forEmpty && this.params.processedForType === "journey") {
+      return { queryIds, page };
+    }
+
+    while (retrieved >= this.pageSize) {
+      const qb = new ClickHouseQueryBuilder();
+      // Applies a concurrency limit to the query
+
+      retrieved = await withSpan(
+        { name: "process-assignments-query-page" },
+        async (pageSpan) => {
+          const offset = page * this.pageSize;
+          const { journeys, ...processAssignmentsParams } = this.params;
+          const pageQueryId = getChCompatibleUuid();
+          queryIds.push(pageQueryId);
+
+          pageSpan.setAttribute("workspaceId", this.params.workspaceId);
+          pageSpan.setAttribute("forEmpty", forEmpty);
+          pageSpan.setAttribute(
+            "computedPropertyId",
+            this.params.computedPropertyId,
+          );
+          pageSpan.setAttribute("type", this.params.type);
+          pageSpan.setAttribute(
+            "processedForType",
+            this.params.processedForType,
+          );
+          pageSpan.setAttribute("page", page);
+          pageSpan.setAttribute("pageSize", this.pageSize);
+          pageSpan.setAttribute("queryId", pageQueryId);
+          pageSpan.setAttribute(
+            "computedPropertyVersion",
+            this.params.computedPropertyVersion,
+          );
+
+          return readLimit()(async () => {
+            const query = buildProcessAssignmentsQuery({
+              ...processAssignmentsParams,
+              forEmpty,
+              limit: this.pageSize,
+              offset,
+              qb,
+            });
+            // Both paginates through the assignments, and streams results
+            // within a given page
+            const pageRetrieved = await streamProcessAssignmentsPage({
+              query,
+              workspaceId: this.params.workspaceId,
+              qb,
+              journeys,
+              queryId: pageQueryId,
+            });
+            pageSpan.setAttribute("retrieved", pageRetrieved);
+            return pageRetrieved;
+          });
+        },
+      );
+      logger().info(
+        {
+          workspaceId: this.params.workspaceId,
+          computedPropertyId: this.params.computedPropertyId,
+          type: this.params.type,
+          processedForType: this.params.processedForType,
+          retrieved,
+        },
+        "retrieved assignments",
+      );
+      page += 1;
+    }
+    return { queryIds, page };
+  }
+
+  async processNonEmpty() {}
+
+  async processEmpty() {}
+
+  // async processV1() {
+  //   return withSpan({ name: "process-assignments-query" }, async (span) => {
+  //     span.setAttribute("workspaceId", this.params.workspaceId);
+  //     span.setAttribute("computedPropertyId", this.params.computedPropertyId);
+  //     span.setAttribute("type", this.params.type);
+  //     span.setAttribute("processedForType", this.params.processedForType);
+  //     span.setAttribute(
+  //       "computedPropertyVersion",
+  //       this.params.computedPropertyVersion,
+  //     );
+  //     const queryIds: string[] = [];
+
+  //     let retrieved = this.pageSize;
+  //     while (retrieved >= this.pageSize) {
+  //       const qb = new ClickHouseQueryBuilder();
+  //       // Applies a concurrency limit to the query
+
+  //       retrieved = await withSpan(
+  //         { name: "process-assignments-query-page" },
+  //         async (pageSpan) => {
+  //           const offset = this.page * this.pageSize;
+  //           const { journeys, ...processAssignmentsParams } = this.params;
+  //           const pageQueryId = getChCompatibleUuid();
+  //           queryIds.push(pageQueryId);
+
+  //           pageSpan.setAttribute("workspaceId", this.params.workspaceId);
+  //           pageSpan.setAttribute(
+  //             "computedPropertyId",
+  //             this.params.computedPropertyId,
+  //           );
+  //           pageSpan.setAttribute("type", this.params.type);
+  //           pageSpan.setAttribute(
+  //             "processedForType",
+  //             this.params.processedForType,
+  //           );
+  //           pageSpan.setAttribute("page", this.page);
+  //           pageSpan.setAttribute("pageSize", this.pageSize);
+  //           pageSpan.setAttribute("queryId", pageQueryId);
+  //           pageSpan.setAttribute(
+  //             "computedPropertyVersion",
+  //             this.params.computedPropertyVersion,
+  //           );
+
+  //           return readLimit()(async () => {
+  //             const query = buildProcessAssignmentsQuery({
+  //               ...processAssignmentsParams,
+  //               limit: this.pageSize,
+  //               offset,
+  //               qb,
+  //             });
+  //             // Both paginates through the assignments, and streams results
+  //             // within a given page
+  //             const pageRetrieved = await streamProcessAssignmentsPage({
+  //               query,
+  //               workspaceId: this.params.workspaceId,
+  //               qb,
+  //               journeys,
+  //               queryId: pageQueryId,
+  //             });
+  //             pageSpan.setAttribute("retrieved", pageRetrieved);
+  //             return pageRetrieved;
+  //           });
+  //         },
+  //       );
+  //       logger().info(
+  //         {
+  //           workspaceId: this.params.workspaceId,
+  //           computedPropertyId: this.params.computedPropertyId,
+  //           type: this.params.type,
+  //           processedForType: this.params.processedForType,
+  //           retrieved,
+  //         },
+  //         "retrieved assignments",
+  //       );
+  //       this.page += 1;
+  //     }
+
+  //     span.setAttribute("processedPages", this.page);
+  //     span.setAttribute("queryIds", queryIds);
+  //   });
+  // }
 }
 
 export async function processAssignments({
@@ -3511,7 +3735,6 @@ export async function processAssignments({
         computedPropertyId: segment.id,
         periodByComputedPropertyId,
         computedPropertyVersion: segment.definitionUpdatedAt.toString(),
-        now,
         journeys,
       });
       assignmentProcessors.push(processor);
@@ -3554,7 +3777,6 @@ export async function processAssignments({
           processedFor: integrationName,
           periodByComputedPropertyId,
           computedPropertyVersion: segment.definitionUpdatedAt.toString(),
-          now,
           journeys,
         });
         assignmentProcessors.push(processor);
@@ -3577,7 +3799,6 @@ export async function processAssignments({
           processedFor: integrationName,
           periodByComputedPropertyId,
           computedPropertyVersion: userProperty.definitionUpdatedAt.toString(),
-          now,
           journeys,
         });
         assignmentProcessors.push(processor);

--- a/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
+++ b/packages/backend-lib/src/computedProperties/computePropertiesIncremental.ts
@@ -3161,10 +3161,10 @@ function buildProcessAssignmentsQuery({
     let existingNonEmptyCondition: string;
     switch (type) {
       case "segment":
-        existingNonEmptyCondition = "pcp.latest_segment_value = true";
+        existingNonEmptyCondition = "pcp.segment_value = true";
         break;
       case "user_property":
-        existingNonEmptyCondition = `pcp.latest_user_property_value != '""' AND pcp.latest_user_property_value != ''`;
+        existingNonEmptyCondition = `pcp.user_property_value != '""' AND pcp.user_property_value != ''`;
         break;
     }
     return `
@@ -3475,92 +3475,6 @@ class AssignmentProcessor {
     }
     return { queryIds, page };
   }
-
-  async processNonEmpty() {}
-
-  async processEmpty() {}
-
-  // async processV1() {
-  //   return withSpan({ name: "process-assignments-query" }, async (span) => {
-  //     span.setAttribute("workspaceId", this.params.workspaceId);
-  //     span.setAttribute("computedPropertyId", this.params.computedPropertyId);
-  //     span.setAttribute("type", this.params.type);
-  //     span.setAttribute("processedForType", this.params.processedForType);
-  //     span.setAttribute(
-  //       "computedPropertyVersion",
-  //       this.params.computedPropertyVersion,
-  //     );
-  //     const queryIds: string[] = [];
-
-  //     let retrieved = this.pageSize;
-  //     while (retrieved >= this.pageSize) {
-  //       const qb = new ClickHouseQueryBuilder();
-  //       // Applies a concurrency limit to the query
-
-  //       retrieved = await withSpan(
-  //         { name: "process-assignments-query-page" },
-  //         async (pageSpan) => {
-  //           const offset = this.page * this.pageSize;
-  //           const { journeys, ...processAssignmentsParams } = this.params;
-  //           const pageQueryId = getChCompatibleUuid();
-  //           queryIds.push(pageQueryId);
-
-  //           pageSpan.setAttribute("workspaceId", this.params.workspaceId);
-  //           pageSpan.setAttribute(
-  //             "computedPropertyId",
-  //             this.params.computedPropertyId,
-  //           );
-  //           pageSpan.setAttribute("type", this.params.type);
-  //           pageSpan.setAttribute(
-  //             "processedForType",
-  //             this.params.processedForType,
-  //           );
-  //           pageSpan.setAttribute("page", this.page);
-  //           pageSpan.setAttribute("pageSize", this.pageSize);
-  //           pageSpan.setAttribute("queryId", pageQueryId);
-  //           pageSpan.setAttribute(
-  //             "computedPropertyVersion",
-  //             this.params.computedPropertyVersion,
-  //           );
-
-  //           return readLimit()(async () => {
-  //             const query = buildProcessAssignmentsQuery({
-  //               ...processAssignmentsParams,
-  //               limit: this.pageSize,
-  //               offset,
-  //               qb,
-  //             });
-  //             // Both paginates through the assignments, and streams results
-  //             // within a given page
-  //             const pageRetrieved = await streamProcessAssignmentsPage({
-  //               query,
-  //               workspaceId: this.params.workspaceId,
-  //               qb,
-  //               journeys,
-  //               queryId: pageQueryId,
-  //             });
-  //             pageSpan.setAttribute("retrieved", pageRetrieved);
-  //             return pageRetrieved;
-  //           });
-  //         },
-  //       );
-  //       logger().info(
-  //         {
-  //           workspaceId: this.params.workspaceId,
-  //           computedPropertyId: this.params.computedPropertyId,
-  //           type: this.params.type,
-  //           processedForType: this.params.processedForType,
-  //           retrieved,
-  //         },
-  //         "retrieved assignments",
-  //       );
-  //       this.page += 1;
-  //     }
-
-  //     span.setAttribute("processedPages", this.page);
-  //     span.setAttribute("queryIds", queryIds);
-  //   });
-  // }
 }
 
 export async function processAssignments({
@@ -3661,7 +3575,6 @@ export async function processAssignments({
         computedPropertyId: userProperty.id,
         periodByComputedPropertyId,
         computedPropertyVersion: userProperty.definitionUpdatedAt.toString(),
-        now,
         journeys,
       });
       assignmentProcessors.push(processor);
@@ -3694,7 +3607,6 @@ export async function processAssignments({
           processedFor: journeyId,
           periodByComputedPropertyId,
           computedPropertyVersion: segment.definitionUpdatedAt.toString(),
-          now,
           journeys,
         });
         assignmentProcessors.push(processor);


### PR DESCRIPTION
- split up processed assignments query to remove join
- one query for empty assignments, one for non-empty