### PR TITLE
fix: tiptap typography breaks liquid templates

### DIFF
--- a/packages/emailo/src/tipTapExtensions.ts
+++ b/packages/emailo/src/tipTapExtensions.ts
@@ -53,7 +53,12 @@ export function getExtensions({
       FontFamily.configure({
         fonts: ["Arial", "Helvetica", "sans-serif"],
       } as any),
-      Typography,
+      Typography.configure({
+        openDoubleQuote: '"',
+        closeDoubleQuote: '"',
+        openSingleQuote: "'",
+        closeSingleQuote: "'",
+      }),
       TextAlign.configure({
         types: ["paragraph"],
         alignments: ["left", "center", "right", "justify"],


### PR DESCRIPTION
by default the typography extension replaces doublequotes with `“` and singlequotes with `’` which breaks liquid templates. fixes #1104 