### PR TITLE
emailo: fix image link in README.md

### DIFF
--- a/packages/emailo/README.md
+++ b/packages/emailo/README.md
@@ -2,5 +2,5 @@
 
 Emailo is Dittofeed's notion-like low-code email editor. [Dittofeed](https://dittofeed.com) is an open source customer engagement platform.
 
-![Emailo Editor Screenshot](https://raw.githubusercontent.com/dittofeed/dittofeed/main/packages/emailo/docs/emailo-screenshot.png)
+![Emailo Editor Screenshot](./emailo-screenshot.png)
 


### PR DESCRIPTION
I found this project on HackerNews and noticed a link issue in readme. I can not see the screenshot.