### PR TITLE
Use https github clone instead of SSH

### DIFF
--- a/packages/docs/deployment/self-hosted/docker-compose.mdx
+++ b/packages/docs/deployment/self-hosted/docker-compose.mdx
@@ -18,7 +18,7 @@ Watch the following video walkthrough to see how to set up Dittofeed with docker
 First, clone Dittofeed's github repository.
 
 ```bash
-git clone git@github.com:dittofeed/dittofeed.git
+git clone https://github.com/dittofeed/dittofeed.git
 cd dittofeed
 ```
 


### PR DESCRIPTION
In documentation, we use ssh based github clone. This might fail if the user has not put in his key in github settings. HTTPS is sure shot of getting this done.