### PR TITLE
allow journey event keys to be numbers

### DIFF
--- a/packages/backend-lib/src/apps.test.ts
+++ b/packages/backend-lib/src/apps.test.ts
@@ -1,8 +1,16 @@
+import NodeCache from "node-cache";
 import { v4 as uuidv4 } from "uuid";
 
+import { submitBatchWithTriggers } from "./apps";
 import { submitBatch } from "./apps/batch";
+import { triggerEventEntryJourneysFactory } from "./journeys";
 import prisma from "./prisma";
-import { EventType } from "./types";
+import {
+  EventType,
+  JourneyDefinition,
+  JourneyNodeType,
+  JourneyStatus,
+} from "./types";
 import { findManyEventsWithCount } from "./userEvents";
 
 describe("apps", () => {
@@ -43,6 +51,104 @@ describe("apps", () => {
           "{}",
           "{}",
         ]);
+      });
+    });
+  });
+  describe("submitBatchWithTriggers", () => {
+    let workspaceId: string;
+    let startKeyedJourneyImpl: jest.Mock;
+    let notStartedJourneyId: string;
+    let startedEventTriggeredJourneyId: string;
+    let segmentEntryJourneyId: string;
+
+    beforeEach(async () => {
+      workspaceId = uuidv4();
+      await prisma().workspace.create({
+        data: { id: workspaceId, name: `test-${workspaceId}` },
+      });
+      const eventTriggeredJourneyDefinition: JourneyDefinition = {
+        entryNode: {
+          type: JourneyNodeType.EventEntryNode,
+          event: "Purchase",
+          child: JourneyNodeType.ExitNode,
+        },
+        nodes: [],
+        exitNode: {
+          type: JourneyNodeType.ExitNode,
+        },
+      };
+      segmentEntryJourneyId = uuidv4();
+      notStartedJourneyId = uuidv4();
+      startedEventTriggeredJourneyId = uuidv4();
+
+      await Promise.all([
+        prisma().journey.create({
+          data: {
+            id: notStartedJourneyId,
+            name: "not started",
+            status: JourneyStatus.NotStarted,
+            workspaceId,
+            definition: eventTriggeredJourneyDefinition,
+          },
+        }),
+        prisma().journey.create({
+          data: {
+            id: startedEventTriggeredJourneyId,
+            name: "started event triggered",
+            status: JourneyStatus.Running,
+            workspaceId,
+            definition: eventTriggeredJourneyDefinition,
+          },
+        }),
+        prisma().journey.create({
+          data: {
+            id: segmentEntryJourneyId,
+            name: "segment entry",
+            status: JourneyStatus.Running,
+            workspaceId,
+            definition: eventTriggeredJourneyDefinition,
+          },
+        }),
+      ]);
+
+      startKeyedJourneyImpl = jest.fn();
+
+      // Custom implementation
+      jest.mock("./journeys", () => {
+        return triggerEventEntryJourneysFactory({
+          journeyCache: new NodeCache(),
+          startKeyedJourneyImpl,
+        });
+      });
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+    });
+
+    it("should trigger journeys for each event", async () => {
+      const userId1 = uuidv4();
+      const userId2 = uuidv4();
+
+      await submitBatchWithTriggers({
+        workspaceId,
+        data: {
+          batch: [
+            {
+              type: EventType.Track,
+              event: "Purchase",
+              messageId: uuidv4(),
+              userId: userId1,
+              properties: { amount: 100 },
+            },
+            {
+              type: EventType.Identify,
+              messageId: uuidv4(),
+              userId: userId2,
+              traits: { name: "Test User" },
+            },
+          ],
+        },
       });
     });
   });

--- a/packages/backend-lib/src/apps.test.ts
+++ b/packages/backend-lib/src/apps.test.ts
@@ -137,7 +137,7 @@ describe("apps", () => {
       submitBatchWithTriggers = apps.submitBatchWithTriggers;
     });
 
-    it.only("it should trigger journeys for users with matching events", async () => {
+    it("it should trigger journeys for users with matching events", async () => {
       const userId1 = uuidv4();
       const userId2 = uuidv4();
 
@@ -151,6 +151,12 @@ describe("apps", () => {
               messageId: uuidv4(),
               userId: userId1,
               properties: { amount: 100 },
+            },
+            {
+              type: EventType.Track,
+              event: "missing-event",
+              messageId: uuidv4(),
+              userId: userId1,
             },
             {
               type: EventType.Identify,

--- a/packages/backend-lib/src/apps.test.ts
+++ b/packages/backend-lib/src/apps.test.ts
@@ -60,16 +60,18 @@ describe("apps", () => {
     let notStartedJourneyId: string;
     let startedEventTriggeredJourneyId: string;
     let segmentEntryJourneyId: string;
+    let entryEventName: string;
 
     beforeEach(async () => {
       workspaceId = uuidv4();
       await prisma().workspace.create({
         data: { id: workspaceId, name: `test-${workspaceId}` },
       });
+      entryEventName = "Purchase";
       const eventTriggeredJourneyDefinition: JourneyDefinition = {
         entryNode: {
           type: JourneyNodeType.EventEntryNode,
-          event: "Purchase",
+          event: entryEventName,
           child: JourneyNodeType.ExitNode,
         },
         nodes: [],
@@ -126,7 +128,7 @@ describe("apps", () => {
       jest.resetModules();
     });
 
-    it("should trigger journeys for each event", async () => {
+    it.only("it should trigger journeys for users with matching events", async () => {
       const userId1 = uuidv4();
       const userId2 = uuidv4();
 
@@ -136,7 +138,7 @@ describe("apps", () => {
           batch: [
             {
               type: EventType.Track,
-              event: "Purchase",
+              event: entryEventName,
               messageId: uuidv4(),
               userId: userId1,
               properties: { amount: 100 },
@@ -149,6 +151,11 @@ describe("apps", () => {
             },
           ],
         },
+      });
+      expect(startKeyedJourneyImpl).toHaveBeenCalledTimes(1);
+      expect(startKeyedJourneyImpl).toHaveBeenCalledWith({
+        journeyId: startedEventTriggeredJourneyId,
+        userId: userId1,
       });
     });
   });

--- a/packages/backend-lib/src/apps.test.ts
+++ b/packages/backend-lib/src/apps.test.ts
@@ -79,6 +79,17 @@ describe("apps", () => {
           type: JourneyNodeType.ExitNode,
         },
       };
+      const segmentEntryJourneyDefinition: JourneyDefinition = {
+        entryNode: {
+          type: JourneyNodeType.SegmentEntryNode,
+          segment: "test-segment",
+          child: JourneyNodeType.ExitNode,
+        },
+        nodes: [],
+        exitNode: {
+          type: JourneyNodeType.ExitNode,
+        },
+      };
       segmentEntryJourneyId = uuidv4();
       notStartedJourneyId = uuidv4();
       startedEventTriggeredJourneyId = uuidv4();
@@ -108,7 +119,7 @@ describe("apps", () => {
             name: "segment entry",
             status: JourneyStatus.Running,
             workspaceId,
-            definition: eventTriggeredJourneyDefinition,
+            definition: segmentEntryJourneyDefinition,
           },
         }),
       ]);
@@ -151,10 +162,12 @@ describe("apps", () => {
         },
       });
       expect(startKeyedJourneyImpl).toHaveBeenCalledTimes(1);
-      expect(startKeyedJourneyImpl).toHaveBeenCalledWith({
-        journeyId: startedEventTriggeredJourneyId,
-        userId: userId1,
-      });
+      expect(startKeyedJourneyImpl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          journeyId: startedEventTriggeredJourneyId,
+          userId: userId1,
+        }),
+      );
     });
   });
 });

--- a/packages/backend-lib/src/apps.test.ts
+++ b/packages/backend-lib/src/apps.test.ts
@@ -1,7 +1,6 @@
 import NodeCache from "node-cache";
 import { v4 as uuidv4 } from "uuid";
 
-import { submitBatchWithTriggers } from "./apps";
 import { submitBatch } from "./apps/batch";
 import { triggerEventEntryJourneysFactory } from "./journeys";
 import prisma from "./prisma";
@@ -61,6 +60,7 @@ describe("apps", () => {
     let startedEventTriggeredJourneyId: string;
     let segmentEntryJourneyId: string;
     let entryEventName: string;
+    let submitBatchWithTriggers: typeof import("./apps").submitBatchWithTriggers;
 
     beforeEach(async () => {
       workspaceId = uuidv4();
@@ -116,16 +116,14 @@ describe("apps", () => {
       startKeyedJourneyImpl = jest.fn();
 
       // Custom implementation
-      jest.mock("./journeys", () => {
-        return triggerEventEntryJourneysFactory({
+      jest.mock("./journeys", () => ({
+        triggerEventEntryJourneys: triggerEventEntryJourneysFactory({
           journeyCache: new NodeCache(),
           startKeyedJourneyImpl,
-        });
-      });
-    });
-
-    afterEach(() => {
-      jest.resetModules();
+        }),
+      }));
+      const apps = await import("./apps");
+      submitBatchWithTriggers = apps.submitBatchWithTriggers;
     });
 
     it.only("it should trigger journeys for users with matching events", async () => {

--- a/packages/backend-lib/src/apps.test.ts
+++ b/packages/backend-lib/src/apps.test.ts
@@ -73,6 +73,7 @@ describe("apps", () => {
           type: JourneyNodeType.EventEntryNode,
           event: entryEventName,
           child: JourneyNodeType.ExitNode,
+          key: "itemId",
         },
         nodes: [],
         exitNode: {
@@ -150,7 +151,7 @@ describe("apps", () => {
               event: entryEventName,
               messageId: uuidv4(),
               userId: userId1,
-              properties: { amount: 100 },
+              properties: { amount: 100, itemId: "123" },
             },
             {
               type: EventType.Track,

--- a/packages/backend-lib/src/apps.ts
+++ b/packages/backend-lib/src/apps.ts
@@ -15,7 +15,6 @@ import {
   TrackData,
 } from "./types";
 import { InsertUserEvent, insertUserEvents } from "./userEvents";
-import logger from "./logger";
 
 export async function submitIdentify({
   workspaceId,
@@ -117,21 +116,9 @@ export async function submitBatchWithTriggers({
 
   const triggers: TriggerEventEntryJourneysOptions[] = data.batch.flatMap(
     (message) => {
-      logger().debug(
-        {
-          message,
-        },
-        "loc1",
-      );
       if (message.type !== EventType.Track) {
         return [];
       }
-      logger().debug(
-        {
-          message,
-        },
-        "loc2",
-      );
       let userOrAnonymousId: string | null = null;
       if ("userId" in message) {
         userOrAnonymousId = message.userId;
@@ -141,12 +128,6 @@ export async function submitBatchWithTriggers({
       if (!userOrAnonymousId) {
         return [];
       }
-      logger().debug(
-        {
-          message,
-        },
-        "loc3",
-      );
       return {
         workspaceId,
         event: message,

--- a/packages/backend-lib/src/apps.ts
+++ b/packages/backend-lib/src/apps.ts
@@ -15,6 +15,7 @@ import {
   TrackData,
 } from "./types";
 import { InsertUserEvent, insertUserEvents } from "./userEvents";
+import logger from "./logger";
 
 export async function submitIdentify({
   workspaceId,
@@ -116,9 +117,21 @@ export async function submitBatchWithTriggers({
 
   const triggers: TriggerEventEntryJourneysOptions[] = data.batch.flatMap(
     (message) => {
+      logger().debug(
+        {
+          message,
+        },
+        "loc1",
+      );
       if (message.type !== EventType.Track) {
         return [];
       }
+      logger().debug(
+        {
+          message,
+        },
+        "loc2",
+      );
       let userOrAnonymousId: string | null = null;
       if ("userId" in message) {
         userOrAnonymousId = message.userId;
@@ -128,6 +141,12 @@ export async function submitBatchWithTriggers({
       if (!userOrAnonymousId) {
         return [];
       }
+      logger().debug(
+        {
+          message,
+        },
+        "loc3",
+      );
       return {
         workspaceId,
         event: message,

--- a/packages/backend-lib/src/journeys.ts
+++ b/packages/backend-lib/src/journeys.ts
@@ -739,7 +739,16 @@ export function triggerEventEntryJourneysFactory({
         ) {
           return [];
         }
-        logger().debug("loc6");
+        logger().debug(
+          {
+            journeyId: journey.id,
+            userId,
+            journeyStatus: journey.status,
+            requiredEvent: journey.definition.entryNode.event,
+            actualEvent: triggerEvent.event,
+          },
+          "loc6",
+        );
         return {
           event: journey.definition.entryNode.event,
           journeyId: journey.id,
@@ -764,6 +773,8 @@ export function triggerEventEntryJourneysFactory({
 
         logger().debug(
           {
+            journeyId,
+            userId,
             journeyEvent,
             triggerEvent,
           },

--- a/packages/backend-lib/src/journeys.ts
+++ b/packages/backend-lib/src/journeys.ts
@@ -702,6 +702,12 @@ export function triggerEventEntryJourneysFactory({
     let journeyDetails: EventTriggerJourneyDetails[] | undefined =
       journeyCache.get(workspaceId);
 
+    logger().debug(
+      {
+        journeyDetails,
+      },
+      "loc4",
+    );
     if (!journeyDetails) {
       const allJourneys = await prisma().journey.findMany({
         where: {
@@ -721,12 +727,19 @@ export function triggerEventEntryJourneysFactory({
           return [];
         }
         const journey = result.value;
+        logger().debug(
+          {
+            journey,
+          },
+          "loc5",
+        );
         if (
           journey.status !== JourneyStatus.Running ||
           journey.definition.entryNode.type !== JourneyNodeType.EventEntryNode
         ) {
           return [];
         }
+        logger().debug("loc6");
         return {
           event: journey.definition.entryNode.event,
           journeyId: journey.id,
@@ -739,17 +752,30 @@ export function triggerEventEntryJourneysFactory({
     const starts: Promise<unknown>[] = journeyDetails.flatMap(
       ({ journeyId, event: journeyEvent, definition }) => {
         if (journeyEvent !== triggerEvent.event) {
+          logger().debug(
+            {
+              journeyEvent,
+              triggerEvent,
+            },
+            "loc7",
+          );
           return [];
         }
-        return [
-          startKeyedJourneyImpl({
-            workspaceId,
-            userId,
-            journeyId,
-            event: triggerEvent,
-            definition,
-          }),
-        ];
+
+        logger().debug(
+          {
+            journeyEvent,
+            triggerEvent,
+          },
+          "loc8",
+        );
+        return startKeyedJourneyImpl({
+          workspaceId,
+          userId,
+          journeyId,
+          event: triggerEvent,
+          definition,
+        });
       },
     );
     await Promise.all(starts);

--- a/packages/backend-lib/src/journeys.ts
+++ b/packages/backend-lib/src/journeys.ts
@@ -702,12 +702,6 @@ export function triggerEventEntryJourneysFactory({
     let journeyDetails: EventTriggerJourneyDetails[] | undefined =
       journeyCache.get(workspaceId);
 
-    logger().debug(
-      {
-        journeyDetails,
-      },
-      "loc4",
-    );
     if (!journeyDetails) {
       const allJourneys = await prisma().journey.findMany({
         where: {
@@ -727,28 +721,12 @@ export function triggerEventEntryJourneysFactory({
           return [];
         }
         const journey = result.value;
-        logger().debug(
-          {
-            journey,
-          },
-          "loc5",
-        );
         if (
           journey.status !== JourneyStatus.Running ||
           journey.definition.entryNode.type !== JourneyNodeType.EventEntryNode
         ) {
           return [];
         }
-        logger().debug(
-          {
-            journeyId: journey.id,
-            userId,
-            journeyStatus: journey.status,
-            requiredEvent: journey.definition.entryNode.event,
-            actualEvent: triggerEvent.event,
-          },
-          "loc6",
-        );
         return {
           event: journey.definition.entryNode.event,
           journeyId: journey.id,
@@ -761,25 +739,9 @@ export function triggerEventEntryJourneysFactory({
     const starts: Promise<unknown>[] = journeyDetails.flatMap(
       ({ journeyId, event: journeyEvent, definition }) => {
         if (journeyEvent !== triggerEvent.event) {
-          logger().debug(
-            {
-              journeyEvent,
-              triggerEvent,
-            },
-            "loc7",
-          );
           return [];
         }
 
-        logger().debug(
-          {
-            journeyId,
-            userId,
-            journeyEvent,
-            triggerEvent,
-          },
-          "loc8",
-        );
         return startKeyedJourneyImpl({
           workspaceId,
           userId,

--- a/packages/backend-lib/src/journeys/userWorkflow.ts
+++ b/packages/backend-lib/src/journeys/userWorkflow.ts
@@ -12,7 +12,7 @@ import * as wf from "@temporalio/workflow";
 import { omit } from "remeda";
 import { v5 as uuidV5 } from "uuid";
 
-import { jsonString, jsonValue } from "../jsonPath";
+import { jsonStringOrNumber, jsonValue } from "../jsonPath";
 import { retryExponential } from "../retry";
 import { assertUnreachableSafe } from "../typeAssertions";
 import {
@@ -82,10 +82,12 @@ export function getKeyedUserJourneyWorkflowId({
   let keyValue: string;
   if (entryNode.key) {
     key = entryNode.key;
-    const keyValueResult = jsonString({
+    const keyValueResult = jsonStringOrNumber({
       data: event.properties,
       path: key,
-    }).unwrapOr(null);
+    })
+      .map(String)
+      .unwrapOr(null);
     if (!keyValueResult) {
       return null;
     }

--- a/packages/backend-lib/src/jsonPath.ts
+++ b/packages/backend-lib/src/jsonPath.ts
@@ -21,6 +21,20 @@ export function jsonValue({
   return ok(value);
 }
 
+export function jsonStringOrNumber({
+  data,
+  path: rawPath,
+}: {
+  data: unknown;
+  path: string;
+}): Result<string | number, Error> {
+  return jsonValue({ data, path: rawPath }).andThen((v) =>
+    typeof v === "string" || typeof v === "number"
+      ? ok(v)
+      : err(new Error("expected string or number")),
+  );
+}
+
 export function jsonString({
   data,
   path: rawPath,

--- a/packages/backend-lib/src/userWorkflow.test.ts
+++ b/packages/backend-lib/src/userWorkflow.test.ts
@@ -1,0 +1,34 @@
+import { getKeyedUserJourneyWorkflowId } from "./journeys/userWorkflow";
+import { JourneyNodeType } from "./types";
+
+describe("userWorkflow", () => {
+  describe("getKeyedUserJourneyWorkflowId", () => {
+    describe("when the entry node has a key and event has the corresponding key", () => {
+      it("the key should be used in the workflow id", () => {
+        const workspaceId = "31affc62-50e7-438a-ada5-7a2321f338e1";
+        const journeyId = "6000442b-3828-432d-afea-b38bb75c0e4c";
+        const workflowId = getKeyedUserJourneyWorkflowId({
+          workspaceId,
+          userId: "1",
+          journeyId,
+          entryNode: {
+            type: JourneyNodeType.EventEntryNode,
+            event: "classRosterBooking.created",
+            key: "classRosterBookingId",
+            child: JourneyNodeType.ExitNode,
+          },
+          event: {
+            event: "classRosterBooking.created",
+            messageId: "1",
+            properties: {
+              classRosterBookingId: 123,
+            },
+          },
+        });
+        expect(workflowId).not.toBeNull();
+        expect(workflowId).toContain(workspaceId);
+        expect(workflowId).toContain(journeyId);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- previously if event keys e.g. orderId was an integer as opposed to a string, they key would be skipped and the journey would not get started