### PR TITLE
Journey node counts

### DIFF
--- a/packages/backend-lib/src/journeys.ts
+++ b/packages/backend-lib/src/journeys.ts
@@ -594,6 +594,7 @@ export async function getJourneysStats({
     const heritageMap = buildHeritageMap(definition);
 
     for (const node of definition.nodes) {
+      const nodeCount = nodeProcessedMap.get(node.id) ?? 0;
       switch (node.type) {
         case JourneyNodeType.MessageNode: {
           const nodeMessageStats =
@@ -605,6 +606,7 @@ export async function getJourneysStats({
             proportions: {
               childEdge: 100,
             },
+            count: nodeCount,
             ...nodeMessageStats,
           };
           break;
@@ -615,6 +617,7 @@ export async function getJourneysStats({
             proportions: {
               childEdge: 100,
             },
+            count: nodeCount,
           };
           break;
         }
@@ -633,6 +636,7 @@ export async function getJourneysStats({
             proportions: {
               falseChildEdge: percent,
             },
+            count: nodeCount,
           };
           break;
         }
@@ -653,6 +657,7 @@ export async function getJourneysStats({
               proportions: {
                 segmentChildEdge: percent,
               },
+              count: nodeCount,
             };
           }
           break;

--- a/packages/dashboard/src/components/journeys/edgeTypes/workflowEdge.tsx
+++ b/packages/dashboard/src/components/journeys/edgeTypes/workflowEdge.tsx
@@ -79,19 +79,19 @@ export default function WorkflowEdge({
   const getLabelText = (): string => {
     if (stats?.type === NodeStatsType.SegmentSplitNodeStats) {
       if (id.includes("child-0")) {
-        return round(100 - stats.proportions.falseChildEdge, 1).toString();
+        return `${round(100 - stats.proportions.falseChildEdge, 1).toString()} % (${(round((100 - stats.proportions.falseChildEdge) / 100 * stats.count, 0)).toLocaleString()})`;
       }
       if (id.includes("child-1")) {
-        return stats.proportions.falseChildEdge.toString();
+        return `${stats.proportions.falseChildEdge.toString()} % (${round(stats.proportions.falseChildEdge / 100 * stats.count, 0).toLocaleString()})`;
       }
     }
 
     if (stats?.type === NodeStatsType.WaitForNodeStats) {
       if (id.includes("child-0")) {
-        return stats.proportions.segmentChildEdge.toString();
+        return `${stats.proportions.segmentChildEdge.toString()} % (${round(stats.proportions.segmentChildEdge / 100 * stats.count, 0).toLocaleString()})`;
       }
       if (id.includes("child-1")) {
-        return round(100 - stats.proportions.segmentChildEdge, 1).toString();
+        return `${round(100 - stats.proportions.segmentChildEdge, 1).toString()} % (${round((100 - stats.proportions.segmentChildEdge) / 100 * stats.count, 0).toLocaleString()})`;
       }
     }
 
@@ -99,7 +99,7 @@ export default function WorkflowEdge({
       stats?.type === NodeStatsType.DelayNodeStats ||
       stats?.type === NodeStatsType.MessageNodeStats
     ) {
-      return stats.proportions.childEdge.toString();
+      return `${stats.proportions.childEdge.toString()} % (${stats.count.toLocaleString()})`;
     }
 
     return "";
@@ -180,7 +180,7 @@ export default function WorkflowEdge({
                 backgroundColor: "#f0f0f0",
               }}
             >
-              {`${getLabelText()} %`}
+              {getLabelText()}
             </Box>
           </Box>
         </EdgeLabelRenderer>

--- a/packages/isomorphic-lib/src/types.ts
+++ b/packages/isomorphic-lib/src/types.ts
@@ -3406,6 +3406,7 @@ export const MessageNodeStats = Type.Composite([
     proportions: Type.Object({
       childEdge: Type.Number(),
     }),
+    count: Type.Number(),
   }),
 ]);
 
@@ -3416,6 +3417,7 @@ export const DelayNodeStats = Type.Object({
   proportions: Type.Object({
     childEdge: Type.Number(),
   }),
+  count: Type.Number(),
 });
 
 export type DelayNodeStats = Static<typeof DelayNodeStats>;
@@ -3425,6 +3427,7 @@ export const WaitForNodeStats = Type.Object({
   proportions: Type.Object({
     segmentChildEdge: Type.Number(),
   }),
+  count: Type.Number(),
 });
 
 export type WaitForNodeStats = Static<typeof WaitForNodeStats>;
@@ -3434,6 +3437,7 @@ export const SegmentSplitNodeStats = Type.Object({
   proportions: Type.Object({
     falseChildEdge: Type.Number(),
   }),
+  count: Type.Number(),
 });
 
 export type SegmentSplitNodeStats = Static<typeof SegmentSplitNodeStats>;


### PR DESCRIPTION
Added node counts to the journey builder ui, next to the percentages.

A nice addition would be to include entry and exit counts, which are easy to do in the api, but slightly harder to accommodate for in the UI since these nodes don't have exiting stat labels.

Additional potential improvements include:
- success/failure of message nodes
- resetting counts when republishing happens, because new nodes would appear out of sync with older nodes
- unique counts of users vs totals counts (since journeys could be retriggered by the same users)