### PR TITLE
events table utc fix

### DIFF
--- a/packages/dashboard/src/components/eventDetailsSidebar.tsx
+++ b/packages/dashboard/src/components/eventDetailsSidebar.tsx
@@ -122,7 +122,7 @@ function CopyableField({
 }
 
 function TimeField({ label, timestamp }: { label: string; timestamp: string }) {
-  const date = new Date(timestamp);
+  const date = new Date(`${timestamp}Z`);
   const formatted = formatDistanceToNow(date, { addSuffix: true });
 
   const tooltipContent = (

--- a/packages/dashboard/src/components/userEventsTable.tsx
+++ b/packages/dashboard/src/components/userEventsTable.tsx
@@ -152,7 +152,7 @@ interface State {
 type SetState = Updater<State>;
 
 function TimeCell({ timestamp }: { timestamp: string }) {
-  const date = new Date(timestamp);
+  const date = new Date(`${timestamp}Z`);
   const formatted = formatDistanceToNow(date, { addSuffix: true });
 
   const tooltipContent = (


### PR DESCRIPTION
The user events table and events detail sidebar show the wrong time for any user who's not on UTC local time. This is because the events api returns the event_time column from clickhouse that is formatted as DateTime64 which defaults to a UTC date string, however it is stored as a date string without the timezone component.

E.g. an event that occurred at '2025-06-23T22:12:20.307-01:00' gets stored as '2025-06-23 23:12:20.307', which is what the API returns.

Because there's no timezone component in the string, the frontend parses the timestamp '2025-06-23 23:12:20.307' as if it was at local timezone, if you're on timezone UTC -1 then it would show that the event occurred 1 hour in the future. 

To ensure that the date is parsed as UTC in the frontend, we can either modify the api to return a timestamp with a timezone component, or wherever in the frontend when the timestamp is referenced, just add the UTC timezone to it, by appending '+0:00' or 'Z' to it.