### PR TITLE
Converted get journey stats query to utilize new internal_events table instead of user_events_v2

### DIFF
--- a/packages/backend-lib/src/journeys.ts
+++ b/packages/backend-lib/src/journeys.ts
@@ -496,20 +496,16 @@ export async function getJourneysStats({
 
   const query = `
     select
+        journey_id,
         JSON_VALUE(
-            message_raw,
-            '$.properties.journeyId'
-        ) journey_id,
-        JSON_VALUE(
-            message_raw,
-            '$.properties.nodeId'
+            properties,
+            '$.nodeId'
         ) node_id,
         uniq(message_id) as count
-    from user_events_v2
+    from internal_events
     where
         workspace_id = ${workspaceIdQuery}
         and journey_id in ${journeyIdsQuery}
-        and event_type = 'track'
         and event = 'DFJourneyNodeProcessed'
     group by journey_id, node_id
 `;


### PR DESCRIPTION
Leveraging the newly created `internal_events` table, there are a couple of queries in the frontend that take a significant time running off `user_events_v2` that are compatible with `internal_events`.

Below shows the before and after clickhouse query on a 40 mill row user events db, for a specific journey.

Before:
<img width="1907" height="367" alt="journey-stats-before" src="https://github.com/user-attachments/assets/00e4148b-d569-4a4c-ace1-9e1a79b74185" />

After:
<img width="1907" height="366" alt="journey-stats-after" src="https://github.com/user-attachments/assets/496d95d6-f57a-4af9-bae3-14105cda02d8" />


As you can see the query went from taking a _**minute and a half**_ to a _**quarter of a second**_.

**Potential improvement:**
The new still extracts node_id from the properties field in the internal events. It might make even more sense to have that column already pre extracted in this table just like the other columns.

P.S.:
I didn't build the image to check if it would run, I just ran the queries directly in clickhouse and updated the relevant part in the code accordingly.