### PR TITLE
Converted get journey message stats query to utilize new internal_events table instead of user_events_v2

### DIFF
--- a/packages/backend-lib/src/journeys.ts
+++ b/packages/backend-lib/src/journeys.ts
@@ -325,25 +325,24 @@ export async function getJourneyMessageStats({
         count(resolved_message_id) AS count
     FROM (
             SELECT
-                JSON_VALUE(message_raw, '$.properties.journeyId') AS journey_id,
-                JSON_VALUE(message_raw, '$.properties.nodeId') AS node_id,
-                JSON_VALUE(message_raw, '$.properties.runId') AS run_id,
+                journey_id,
+                JSON_VALUE(properties, '$.nodeId') AS node_id,
+                JSON_VALUE(properties, '$.runId') AS run_id,
                 if(
                     (
-                        JSON_VALUE(message_raw, '$.properties.messageId') AS property_message_id
+                        JSON_VALUE(properties, '$.messageId') AS property_message_id
                     ) != '',
                     property_message_id,
                     message_id
                 ) AS resolved_message_id,
                 argMax(event, event_time) as last_event
-            FROM user_events_v2
+            FROM internal_events
             WHERE
                 workspace_id = ${qb.addQueryValue(workspaceId, "String")}
                 AND journey_id in ${qb.addQueryValue(
                   journeyIds,
                   "Array(String)",
                 )}
-                AND (event_type = 'track')
                 AND (event in ${qb.addQueryValue(
                   MESSAGE_EVENTS,
                   "Array(String)",


### PR DESCRIPTION
Just like the previous PR, leveraging the newly created `internal_events` table for the get journey message stats query.

Below shows the before and after clickhouse query on a 40 mill row user events db, for a specific journey.

Before:
<img width="1908" height="368" alt="journey-message-before" src="https://github.com/user-attachments/assets/79b2bf04-0223-4e18-8b93-8ad23d04475b" />

After:
<img width="1908" height="366" alt="journey-message-after" src="https://github.com/user-attachments/assets/999a4ee8-1bb0-4a2e-b438-36ae147e3940" />

As you can see the query went from taking a **_minute and a half_** to a **_half a second_**.

**Potential improvement**:
Just like previous PR, this query also extracts some fields from properties that could potentially be pre extracted as columns: `node_id`, `run_id`, `property_message_id`.
Also, I don't quite get the need for the sub query to have `run_id` and `resolved_message_id` if the parent query isn't utilizing it? But I left it as is just in case it actually does something I'm missing.

P.S.:
Same as before, I ran these queries directly in clickhouse instead of building the image to check if they worked since this was on a production db and didn't want to do stuff there.