### PR TITLE
Fix: Conditionally render warnings in single-tenant page

### DIFF
--- a/packages/dashboard/src/pages/auth/single-tenant.page.tsx
+++ b/packages/dashboard/src/pages/auth/single-tenant.page.tsx
@@ -162,19 +162,21 @@ const SingleTenantAuth: NextPage<SingleTenantAuthProps> =
             Login
           </LoadingButton>
         </Stack>
-        <Stack
-          direction="column"
-          spacing={1}
-          sx={{
-            p: 2,
-            fontWeight: 600,
-            ...getWarningStyles(theme),
-          }}
-        >
-          {warnings.map((warning) => (
-            <li key={warning}>{warning}</li>
-          ))}
-        </Stack>
+        {Boolean(warnings.length) && (
+          <Stack
+            direction="column"
+            spacing={1}
+            sx={{
+              p: 2,
+              fontWeight: 600,
+              ...getWarningStyles(theme),
+            }}
+          >
+            {warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </Stack>
+        )}
       </Stack>
     );
   };


### PR DESCRIPTION
Before: 
<img width="682" height="634" alt="Screenshot 2025-10-16 at 16 22 22@2x" src="https://github.com/user-attachments/assets/64a7eaa8-3e71-4a7a-b74a-13bfc58103aa" />

After:
<img width="674" height="754" alt="Screenshot 2025-10-16 at 16 22 58@2x" src="https://github.com/user-attachments/assets/5f36ef03-24e2-4dc2-ad3f-f693a0575317" />
