### PR TITLE
add additional logging around clickhouse ops

### DIFF
--- a/packages/backend-lib/src/clickhouse.ts
+++ b/packages/backend-lib/src/clickhouse.ts
@@ -261,7 +261,15 @@ export async function command(
       },
       "clickhouse-command",
     );
-    return client.command({ query_id: queryId, ...params });
+    try {
+      return client.command({ query_id: queryId, ...params });
+    } catch (error) {
+      logger().error(
+        { err: error, queryId },
+        "Error executing clickhouse command",
+      );
+      throw error;
+    }
   });
 }
 
@@ -284,10 +292,18 @@ export async function query(
       },
       "clickhouse-query",
     );
-    return client.query<"JSONEachRow">({
-      query_id: queryId,
-      ...params,
-      format: "JSONEachRow",
-    });
+    try {
+      return client.query<"JSONEachRow">({
+        query_id: queryId,
+        ...params,
+        format: "JSONEachRow",
+      });
+    } catch (error) {
+      logger().error(
+        { err: error, queryId },
+        "Error executing clickhouse query",
+      );
+      throw error;
+    }
   });
 }


### PR DESCRIPTION
- expose query id

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds error logging for ClickHouse `command` and `query`, wrapping calls in try/catch to log failures with `queryId` and rethrow.
> 
> - **Backend: ClickHouse client (`packages/backend-lib/src/clickhouse.ts`)**
>   - **Error logging**: Wrap `command()` and `query()` calls in `try/catch`; on failure, log errors with `queryId` and rethrow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab5ce37e74b40cfc454fdfd69ba7acd852ebca25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->