### PR TITLE
prevent manual segments from having status updated

### DIFF
--- a/packages/api/src/controllers/segmentsController.ts
+++ b/packages/api/src/controllers/segmentsController.ts
@@ -33,6 +33,7 @@ import {
   schemaValidateWithErr,
 } from "isomorphic-lib/src/resultHandling/schemaValidation";
 import {
+  BaseMessageResponse,
   BaseUserUploadRow,
   BatchItem,
   ClearManualSegmentRequest,
@@ -175,6 +176,7 @@ export default async function segmentsController(fastify: FastifyInstance) {
         body: UpdateSegmentStatusRequest,
         response: {
           200: SavedSegmentResource,
+          400: BaseMessageResponse,
           404: EmptyResponse,
         },
       },
@@ -188,11 +190,16 @@ export default async function segmentsController(fastify: FastifyInstance) {
         id,
         status,
       });
-      if (!updated) {
+      if (updated.isErr()) {
+        return reply.status(400).send({
+          message: updated.error.message,
+        });
+      }
+      if (!updated.value) {
         return reply.status(404).send();
       }
 
-      return reply.status(200).send(updated);
+      return reply.status(200).send(updated.value);
     },
   );
 

--- a/packages/backend-lib/src/segments.ts
+++ b/packages/backend-lib/src/segments.ts
@@ -1074,7 +1074,9 @@ export async function updateSegmentStatus({
   workspaceId,
   id,
   status,
-}: UpdateSegmentStatusRequest): Promise<Result<SavedSegmentResource, Error>> {
+}: UpdateSegmentStatusRequest): Promise<
+  Result<SavedSegmentResource | null, Error>
+> {
   return db().transaction(async (tx) => {
     // Fetch the segment to check if it's manual
     const segment = await tx.query.segment.findFirst({
@@ -1082,7 +1084,7 @@ export async function updateSegmentStatus({
     });
 
     if (!segment) {
-      return err(new Error("Segment not found"));
+      return ok(null);
     }
 
     // Check if the segment definition is valid and if it's a manual segment


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disallows status changes for manual segments, refactors `updateSegmentStatus` to return a Result with validation/transactions, and updates the API to return 400 with a message on errors.
> 
> - **Backend (segments)**:
>   - Refactor `updateSegmentStatus` to return `Result<SavedSegmentResource | null, Error>` and run in a transaction.
>   - Validate segment definition; if manual (`SegmentNodeType.Manual`), return error to prevent status changes.
>   - Return explicit errors on update/serialization failures.
> - **API**:
>   - `PATCH /segments/status` now returns `400` (`BaseMessageResponse`) on errors and `404` when segment not found; sends updated resource on success.
>   - Import `BaseMessageResponse` and update response schema accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddc8f9af598851cbd3486212527de1a15fa9940e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->