### PR TITLE
fix(postmark): sanitize metadata to meet API constraints

### DIFF
--- a/packages/backend-lib/src/destinations/postmark.test.ts
+++ b/packages/backend-lib/src/destinations/postmark.test.ts
@@ -1,4 +1,5 @@
 import { DefaultResponse } from "postmark/dist/client/models/client/DefaultResponse";
+import { MESSAGE_METADATA_FIELDS } from "../constants";
 
 describe("postmark", () => {
   // Reset modules before each test to clear module cache
@@ -80,6 +81,244 @@ describe("postmark", () => {
             },
           }),
         ).rejects.toThrow(thrownError);
+      });
+    });
+
+    describe("metadata sanitization", () => {
+      it("should sanitize metadata with more than 10 fields", async () => {
+        const mockSendEmail = jest.fn().mockResolvedValue({
+          ErrorCode: 0,
+          Message: "OK",
+        });
+
+        jest.doMock("postmark", () => {
+          return {
+            ServerClient: jest.fn().mockImplementation(() => ({
+              sendEmail: mockSendEmail,
+            })),
+          };
+        });
+
+        const { sendMail } = await import("./postmark");
+
+        await sendMail({
+          apiKey: "fake-api-key",
+          mailData: {
+            From: "test@example.com",
+            To: "recipient@example.com",
+            Subject: "Test",
+            Metadata: {
+              // Priority fields (MESSAGE_METADATA_FIELDS)
+              workspaceId: "ws-123",
+              userId: "user-123",
+              messageId: "msg-123",
+              templateId: "tpl-123",
+              journeyId: "jrn-123",
+              broadcastId: "brd-123",
+              runId: "run-123",
+              nodeId: "node-123",
+              // Extra fields (these should be dropped)
+              extra1: "value1",
+              extra2: "value2",
+              extra3: "value3",
+            },
+          },
+        });
+
+        // Should only keep first 10 fields (all 8 priority + 2 extra)
+        const sentMetadata = mockSendEmail.mock.calls[0][0].Metadata;
+        expect(Object.keys(sentMetadata)).toHaveLength(10);
+
+        // All MESSAGE_METADATA_FIELDS should be present
+        MESSAGE_METADATA_FIELDS.forEach((field) => {
+          expect(sentMetadata).toHaveProperty(field);
+        });
+      });
+
+      it("should drop fields with keys longer than 20 characters", async () => {
+        const mockSendEmail = jest.fn().mockResolvedValue({
+          ErrorCode: 0,
+          Message: "OK",
+        });
+
+        jest.doMock("postmark", () => {
+          return {
+            ServerClient: jest.fn().mockImplementation(() => ({
+              sendEmail: mockSendEmail,
+            })),
+          };
+        });
+
+        const { sendMail } = await import("./postmark");
+
+        await sendMail({
+          apiKey: "fake-api-key",
+          mailData: {
+            From: "test@example.com",
+            To: "recipient@example.com",
+            Subject: "Test",
+            Metadata: {
+              workspaceId: "ws-123",
+              thisKeyIsWayTooLongForPostmark: "value",
+            },
+          },
+        });
+
+        const sentMetadata = mockSendEmail.mock.calls[0][0].Metadata;
+        expect(sentMetadata).toHaveProperty("workspaceId");
+        expect(sentMetadata).not.toHaveProperty("thisKeyIsWayTooLongForPostmark");
+      });
+
+      it("should drop fields with values longer than 80 characters", async () => {
+        const mockSendEmail = jest.fn().mockResolvedValue({
+          ErrorCode: 0,
+          Message: "OK",
+        });
+
+        jest.doMock("postmark", () => {
+          return {
+            ServerClient: jest.fn().mockImplementation(() => ({
+              sendEmail: mockSendEmail,
+            })),
+          };
+        });
+
+        const { sendMail } = await import("./postmark");
+
+        const longValue = "a".repeat(100);
+
+        await sendMail({
+          apiKey: "fake-api-key",
+          mailData: {
+            From: "test@example.com",
+            To: "recipient@example.com",
+            Subject: "Test",
+            Metadata: {
+              workspaceId: "ws-123",
+              longField: longValue,
+            },
+          },
+        });
+
+        const sentMetadata = mockSendEmail.mock.calls[0][0].Metadata;
+        expect(sentMetadata).toHaveProperty("workspaceId");
+        expect(sentMetadata).not.toHaveProperty("longField");
+      });
+
+      it("should prioritize MESSAGE_METADATA_FIELDS over other fields", async () => {
+        const mockSendEmail = jest.fn().mockResolvedValue({
+          ErrorCode: 0,
+          Message: "OK",
+        });
+
+        jest.doMock("postmark", () => {
+          return {
+            ServerClient: jest.fn().mockImplementation(() => ({
+              sendEmail: mockSendEmail,
+            })),
+          };
+        });
+
+        const { sendMail } = await import("./postmark");
+
+        await sendMail({
+          apiKey: "fake-api-key",
+          mailData: {
+            From: "test@example.com",
+            To: "recipient@example.com",
+            Subject: "Test",
+            Metadata: {
+              // Add 5 non-priority fields first
+              extra1: "value1",
+              extra2: "value2",
+              extra3: "value3",
+              extra4: "value4",
+              extra5: "value5",
+              // Then add MESSAGE_METADATA_FIELDS
+              workspaceId: "ws-123",
+              userId: "user-123",
+              messageId: "msg-123",
+              templateId: "tpl-123",
+              journeyId: "jrn-123",
+              broadcastId: "brd-123",
+              runId: "run-123",
+              nodeId: "node-123",
+            },
+          },
+        });
+
+        const sentMetadata = mockSendEmail.mock.calls[0][0].Metadata;
+        expect(Object.keys(sentMetadata)).toHaveLength(10);
+
+        // All MESSAGE_METADATA_FIELDS should be present
+        MESSAGE_METADATA_FIELDS.forEach((field) => {
+          expect(sentMetadata).toHaveProperty(field);
+        });
+
+        // Only 2 extra fields should be kept (8 priority + 2 extra = 10 total)
+        const extraFieldCount = Object.keys(sentMetadata).filter(
+          (key) => key.startsWith("extra"),
+        ).length;
+        expect(extraFieldCount).toBe(2);
+      });
+
+      it("should handle undefined metadata", async () => {
+        const mockSendEmail = jest.fn().mockResolvedValue({
+          ErrorCode: 0,
+          Message: "OK",
+        });
+
+        jest.doMock("postmark", () => {
+          return {
+            ServerClient: jest.fn().mockImplementation(() => ({
+              sendEmail: mockSendEmail,
+            })),
+          };
+        });
+
+        const { sendMail } = await import("./postmark");
+
+        await sendMail({
+          apiKey: "fake-api-key",
+          mailData: {
+            From: "test@example.com",
+            To: "recipient@example.com",
+            Subject: "Test",
+          },
+        });
+
+        const sentMetadata = mockSendEmail.mock.calls[0][0].Metadata;
+        expect(sentMetadata).toBeUndefined();
+      });
+
+      it("should handle empty metadata", async () => {
+        const mockSendEmail = jest.fn().mockResolvedValue({
+          ErrorCode: 0,
+          Message: "OK",
+        });
+
+        jest.doMock("postmark", () => {
+          return {
+            ServerClient: jest.fn().mockImplementation(() => ({
+              sendEmail: mockSendEmail,
+            })),
+          };
+        });
+
+        const { sendMail } = await import("./postmark");
+
+        await sendMail({
+          apiKey: "fake-api-key",
+          mailData: {
+            From: "test@example.com",
+            To: "recipient@example.com",
+            Subject: "Test",
+            Metadata: {},
+          },
+        });
+
+        const sentMetadata = mockSendEmail.mock.calls[0][0].Metadata;
+        expect(sentMetadata).toBeUndefined();
       });
     });
   });


### PR DESCRIPTION
Postmark API rejects metadata with >10 fields or keys/values exceeding length limits (20 and 80 chars). Added sanitization that prioritizes MESSAGE_METADATA_FIELDS for event tracking and drops invalid fields.

I was getting these error logs when attempting to trigger a broadcast:

`{"level":30,"time":1762682663080,"service.version":"fa45b03","sdkComponent":"workflow","workspaceId":"0ee42aad-51a5-4622-ad80-ebd10b6d79a3","broadcastId":"04b1991e-5f99-4c26-bed3-50c85d49656a","err":{"type":"Error","message":"Activity task failed: Invalid metadata content. Field names are limited to 20 characters and field values are limited to 80 characters in length. The 'workspaceOccupantType' field in your metadata content exceeds these limits.","stack":"\ncaused by: InvalidEmailRequestError: Invalid metadata content. Field names are limited to 20 characters and field values are limited to 80 characters in length. The 'workspaceOccupantType' field in your metadata content exceeds these limits...`

Not entirely sure if this is the best approach - logging and dropping vs. some type of mapping or truncation - but it's working well for me on my self-hosted instance.

It seems to be connected to the google workspace OAuth patch from ~6 months ago, so maybe it's been broken since then and I'm the first to notice.