### PR TITLE
improve users lookup in empty case

### DIFF
--- a/packages/backend-lib/src/users.ts
+++ b/packages/backend-lib/src/users.ts
@@ -213,8 +213,8 @@ export async function getUsers(
         selectUserIdColumns.push(
           `argMax(if(computed_property_id = ${qb.addQueryValue(segmentId, "String")}, segment_value, null), assigned_at) as ${varName}`,
         );
+        hasStrictFilter = true;
       }
-      hasStrictFilter = true;
     }
 
     // [OPTIMIZATION] Implicit Anchor
@@ -747,8 +747,8 @@ export async function getUsersCount({
         `argMax(if(computed_property_id = ${qb.addQueryValue(segmentId, "String")}, segment_value, null), assigned_at) as ${varName}`,
       );
       havingSubClauses.push(`${varName} == True`);
+      hasStrictFilter = true;
     }
-    hasStrictFilter = true;
   }
 
   // [OPTIMIZATION] Implicit Anchor


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds strict-filter detection with an implicit 'id' anchor and limits scanned types to speed up getUsers and getUsersCount, especially when filters are empty.
> 
> - **Backend (ClickHouse queries in `packages/backend-lib/src/users.ts`)**:
>   - **getUsers**:
>     - Detects strict filters and, if absent, injects an implicit `id` property anchor to avoid full scans.
>     - Restricts scanned rows via `type IN ('segment', 'user_property')` based on requested filters or injected anchor.
>     - Expands `computed_property_id` set accordingly and applies the new `type` clause in the inner selection.
>   - **getUsersCount**:
>     - Mirrors the same optimizations: strict-filter detection, implicit `id` anchor, and `type` filtering in the counting subquery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04cc290fd4046685aeb7bc17c7974e5f824b58e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->