### PR TITLE
add postmark messagestream setting

### DIFF
--- a/packages/backend-lib/src/messaging.ts
+++ b/packages/backend-lib/src/messaging.ts
@@ -1525,6 +1525,7 @@ export async function sendEmail({
               }))
             : undefined,
         Metadata: metadata,
+        MessageStream: emailProvider.messageStream,
       };
 
       if (!emailProvider.apiKey) {

--- a/packages/dashboard/src/pages/settings.page.tsx
+++ b/packages/dashboard/src/pages/settings.page.tsx
@@ -999,6 +999,23 @@ function PostMarkConfig() {
                     ),
                   },
                 },
+                {
+                  id: "postmark-message-stream",
+                  type: "secret",
+                  fieldProps: {
+                    name: SecretNames.Postmark,
+                    secretKey: "messageStream",
+                    label: "Message Stream",
+                    helperText:
+                      "Message stream to use for sending emails. Usually 'broadcast'.",
+                    type: EmailProviderType.PostMark,
+                    saved: isSecretSaved(
+                      SecretNames.Postmark,
+                      "messageStream",
+                      secretAvailability,
+                    ),
+                  },
+                },
               ],
             },
           ],

--- a/packages/isomorphic-lib/src/types.ts
+++ b/packages/isomorphic-lib/src/types.ts
@@ -4672,6 +4672,7 @@ export const PostMarkSecret = Type.Object({
   type: Type.Literal(EmailProviderType.PostMark),
   apiKey: Type.Optional(Type.String()),
   webhookKey: Type.Optional(Type.String()),
+  messageStream: Type.Optional(Type.String()),
 });
 
 export type PostMarkSecret = Static<typeof PostMarkSecret>;


### PR DESCRIPTION
Allow to select which PostMark message stream to use, as by default postmark will use the transactional stream which is not appropriate for marketing emails.