### PR TITLE
improve sort UI: reuse email column and exclude id/anonymousId from indices

### DIFF
--- a/packages/dashboard/src/components/usersTable/configureSortIndicesDialog.tsx
+++ b/packages/dashboard/src/components/usersTable/configureSortIndicesDialog.tsx
@@ -42,6 +42,9 @@ import { useUserPropertyResourcesQuery } from "../../lib/useUserPropertyResource
 
 type IndexTypeOption = UserPropertyIndexType | "None";
 
+// Properties that cannot have sort indices created
+const EXCLUDED_PROPERTY_NAMES = ["id", "anonymousId"];
+
 interface ConfigureSortIndicesDialogProps {
   open: boolean;
   onClose: () => void;
@@ -187,7 +190,11 @@ export function ConfigureSortIndicesDialog({
   };
 
   const userProperties = useMemo(() => {
-    return userPropertiesQuery.data?.userProperties ?? [];
+    const properties = userPropertiesQuery.data?.userProperties ?? [];
+    // Filter out id and anonymousId properties
+    return properties.filter(
+      (prop) => !EXCLUDED_PROPERTY_NAMES.includes(prop.name),
+    );
   }, [userPropertiesQuery.data]);
 
   // Only show loading on initial load, not during background refetches

--- a/packages/dashboard/src/components/usersTableV2.tsx
+++ b/packages/dashboard/src/components/usersTableV2.tsx
@@ -851,7 +851,9 @@ function UsersTableInner({
     ];
 
     // Add sort property column second (after User ID) if sorting by a user property
-    if (sortPropertyName && sortBy && sortBy !== "id") {
+    // Skip if sorting by email since we already have an email column
+    const isEmailSort = sortPropertyName?.toLowerCase() === "email";
+    if (sortPropertyName && sortBy && sortBy !== "id" && !isEmailSort) {
       baseColumns.push({
         id: "sortProperty",
         header: sortPropertyName,


### PR DESCRIPTION
- When sorting by email property, reuse existing email column instead of
  creating a duplicate sort property column
- Prevent users from creating sort indices on id and anonymousId properties
  in the Configure Sort Indices dialog
