### PR TITLE
fix: initialize offsetDirection when creating User Property Delay nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,8 @@ mnt/*
 !.tmp/.gitkeep
 
 .editorconfig
+
+# Playwright
+.playwright-mcp/
+playwright-report/
+test-results/

--- a/packages/backend-lib/src/dates.ts
+++ b/packages/backend-lib/src/dates.ts
@@ -1,6 +1,7 @@
 import { add, getUnixTime } from "date-fns";
 import { getTimezoneOffset, zonedTimeToUtc } from "date-fns-tz";
 import { find as findTz } from "geo-tz";
+import { DEFAULT_USER_PROPERTY_DELAY_OFFSET_DIRECTION } from "isomorphic-lib/src/constants";
 
 import logger from "./logger";
 import { LocalTimeDelayVariantFields, UserWorkflowTrackEvent } from "./types";
@@ -172,7 +173,7 @@ export async function getUserPropertyDelay({
   userProperty,
   now,
   offsetSeconds = 0,
-  offsetDirection = "after",
+  offsetDirection = DEFAULT_USER_PROPERTY_DELAY_OFFSET_DIRECTION,
   ...rest
 }: GetUserPropertyDelayParams): Promise<number | null> {
   let events: UserWorkflowTrackEvent[] | undefined;

--- a/packages/dashboard/src/components/journeys/nodeEditor.tsx
+++ b/packages/dashboard/src/components/journeys/nodeEditor.tsx
@@ -21,7 +21,10 @@ import {
 import { SelectInputProps } from "@mui/material/Select/SelectInput";
 import { MultiSectionDigitalClock } from "@mui/x-date-pickers/MultiSectionDigitalClock";
 import { Node } from "@xyflow/react";
-import { DAY_INDICES } from "isomorphic-lib/src/constants";
+import {
+  DAY_INDICES,
+  DEFAULT_USER_PROPERTY_DELAY_OFFSET_DIRECTION,
+} from "isomorphic-lib/src/constants";
 import { getDefaultSubscriptionGroup } from "isomorphic-lib/src/subscriptionGroups";
 import { assertUnreachable } from "isomorphic-lib/src/typeAssertions";
 import {
@@ -1110,6 +1113,7 @@ function DelayNodeFields({
               case DelayVariantType.UserProperty:
                 props.variant = {
                   type: DelayVariantType.UserProperty,
+                  offsetDirection: DEFAULT_USER_PROPERTY_DELAY_OFFSET_DIRECTION,
                 };
                 break;
               default:

--- a/packages/isomorphic-lib/src/constants.ts
+++ b/packages/isomorphic-lib/src/constants.ts
@@ -1,5 +1,6 @@
 import {
   ChannelType,
+  CursorDirectionEnum,
   EmailProviderType,
   InternalEventType,
   JourneyNodeType,
@@ -116,3 +117,6 @@ export const DEFAULT_SEGMENT_DEFINITION: SegmentDefinition = {
 };
 
 export const OAUTH_COOKIE_NAME = "oauth_csrf_token";
+
+export const DEFAULT_USER_PROPERTY_DELAY_OFFSET_DIRECTION =
+  CursorDirectionEnum.After;


### PR DESCRIPTION
When creating a new User Property Delay variant in the journey editor,
offsetDirection was not being initialized, leaving it undefined. This
caused a UI/backend mismatch: the UI displayed "backward" for undefined
values (since undefined !== After), while the backend defaulted to
"after" (forward).

Added a shared constant DEFAULT_USER_PROPERTY_DELAY_OFFSET_DIRECTION in
isomorphic-lib to ensure both frontend and backend use the same default
value, preventing future drift.

Also added Playwright-related directories to .gitignore.
