### PR TITLE
allow non default temporal namespace

### DIFF
--- a/packages/backend-lib/package.json
+++ b/packages/backend-lib/package.json
@@ -61,6 +61,7 @@
     "jsonpath": "^1.1.1",
     "kafkajs": "^2.2.2",
     "liquidjs": "^10.7.1",
+    "long": "^5.2.3",
     "markdown-it": "^13.0.1",
     "minimist": "^1.2.7",
     "mjml": "^4.14.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds automatic Temporal namespace setup for non-default namespaces during backend bootstrap.
> 
> - Introduces `bootstrapTemporalNamespace` that checks for existence, creates the namespace with 3-day retention (`workflowExecutionRetentionPeriod`), and waits until available
> - Skips work when using the `default` namespace; includes retry/polling with bounded attempts
> - Wires namespace bootstrap into `bootstrapDependencies`
> - Adds `long` dependency and uses it to set retention period seconds
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3ecd3addd8b9075366a047e9dd2e49023b6f952. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->