### PR TITLE
worktree setup

### DIFF
--- a/worktree-setup.sh
+++ b/worktree-setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+yarn workspace emailo build
+yarn workspace backend-lib check
+yarn workspace dashboard check
+yarn workspace admin-cli check
+yarn admin bootstrap


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a helper script to initialize a worktree with required builds and checks.
> 
> - Adds `worktree-setup.sh` to run `yarn workspace emailo build`, `backend-lib check`, `dashboard check`, `admin-cli check`, and `yarn admin bootstrap`
> - Ensures fast-fail setup via `set -euo pipefail`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed41e545d55182598492cb1b0045f6112a86d316. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->