### PR TITLE
Add config to skip JSON_EXISTS in pruning

### DIFF
--- a/packages/backend-lib/src/config.ts
+++ b/packages/backend-lib/src/config.ts
@@ -178,6 +178,10 @@ const BaseRawConfigProps = {
     Type.String({ format: "naturalNumber" }),
   ),
   batchChunkSize: Type.Optional(Type.String({ format: "naturalNumber" })),
+  // Skip JSON_EXISTS checks in pruning queries to improve performance for
+  // workspaces with large event volumes. This makes pruning less precise but
+  // avoids expensive JSON parsing during the pruning phase.
+  skipPruneJsonExists: Type.Optional(BoolStr),
 };
 
 function defaultTemporalAddress(inputURL?: string): string {
@@ -314,6 +318,7 @@ export type Config = Overwrite<
     waitForComputePropertiesMaxAttempts: number;
     metricsExportIntervalMs: number;
     batchChunkSize: number;
+    skipPruneJsonExists: boolean;
     // Cold storage timeouts (ms)
     clickhouseColdStorageRequestTimeout?: number;
     clickhouseColdStorageMaxExecutionTime?: number;
@@ -723,6 +728,7 @@ function parseRawConfig(rawConfig: RawConfig): Config {
     batchChunkSize: rawConfig.batchChunkSize
       ? parseInt(rawConfig.batchChunkSize)
       : 100,
+    skipPruneJsonExists: rawConfig.skipPruneJsonExists === "true",
   };
 
   return parsedConfig;


### PR DESCRIPTION
- Add SKIP_PRUNE_JSON_EXISTS env var to config
- Skip expensive JSON_EXISTS checks in pruning queries when enabled
- Fixes timeout issues for workspaces with large event volumes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves pruning performance by making `JSON_EXISTS` checks optional via configuration.
> 
> - Introduces `skipPruneJsonExists` in `config.ts` (schema, types, parsed from env) and exposes it on `Config`
> - Updates pruning query generation in `computePropertiesIncremental.ts` to conditionally include `JSON_EXISTS(properties, path)` for `Trait` and `Performed` user properties and for segment `Trait` nodes
> - No behavioral change when disabled; when enabled, pruning uses only event-type (and prefix) conditions to avoid expensive JSON parsing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1288d9c96ce609745226cdff3f8ea8360b4c65cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->