### PR TITLE
turn off JSON_EXISTS call for pruning by default

### DIFF
--- a/packages/backend-lib/src/config.ts
+++ b/packages/backend-lib/src/config.ts
@@ -728,7 +728,7 @@ function parseRawConfig(rawConfig: RawConfig): Config {
     batchChunkSize: rawConfig.batchChunkSize
       ? parseInt(rawConfig.batchChunkSize)
       : 100,
-    skipPruneJsonExists: rawConfig.skipPruneJsonExists === "true",
+    skipPruneJsonExists: rawConfig.skipPruneJsonExists !== "false",
   };
 
   return parsedConfig;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates pruning behavior defaults for performance.
> 
> - Changes `config.ts` parsing so `skipPruneJsonExists` is true unless explicitly set to `"false"`, effectively disabling `JSON_EXISTS` checks by default in pruning queries
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 993f1742e0d2126e74fbf952d67747b395059f47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->