### PR TITLE
enable more telemetry in lite mode

### DIFF
--- a/packages/lite/src/openTelemetry.ts
+++ b/packages/lite/src/openTelemetry.ts
@@ -1,4 +1,4 @@
-import { API_VIEWS } from "api/src/openTelemetry";
+import { API_TELEMETRY_CONFIG, API_VIEWS } from "api/src/openTelemetry";
 import { initOpenTelemetry } from "backend-lib/src/openTelemetry";
 import { WORKER_VIEWS } from "worker/src/openTelemetry";
 
@@ -6,9 +6,14 @@ import config from "./config";
 
 export function initLiteOpenTelemetry() {
   const liteConfig = config();
+  const meterProviderViews = liteConfig.enableWorker
+    ? [...API_VIEWS, ...WORKER_VIEWS]
+    : API_VIEWS;
+
   const otel = initOpenTelemetry({
     serviceName: liteConfig.serviceName,
-    meterProviderViews: [...API_VIEWS, ...WORKER_VIEWS],
+    configOverrides: API_TELEMETRY_CONFIG,
+    meterProviderViews,
   });
   return otel;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances lite OpenTelemetry setup with API overrides and conditional metric views.
> 
> - Passes `API_TELEMETRY_CONFIG` via `configOverrides` to `initOpenTelemetry`
> - Sets `meterProviderViews` based on `liteConfig.enableWorker` (API-only by default; includes `WORKER_VIEWS` when enabled)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ab484d701442ee3444095391ee0d2cb8903aaef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->