### PR TITLE
Make CH timeout settings configurable

### DIFF
--- a/packages/backend-lib/src/clickhouse.ts
+++ b/packages/backend-lib/src/clickhouse.ts
@@ -131,6 +131,8 @@ function getClientConfig({
     clickhouseDatabase: configDatabase,
     clickhouseUser: configUser,
     clickhousePassword: configPassword,
+    clickhouseMaxExecutionTime,
+    clickhouseMaxMemoryUsage,
   } = config();
 
   const url = paramsHost ?? configHost;
@@ -156,6 +158,8 @@ function getClientConfig({
         maxBytesRatioBeforeExternalGroupBy,
       max_bytes_before_external_group_by: maxBytesBeforeExternalGroupBy,
       date_time_input_format: "best_effort",
+      max_execution_time: clickhouseMaxExecutionTime,
+      max_memory_usage: clickhouseMaxMemoryUsage,
     },
   };
   logger().debug({ clientConfig }, "ClickHouse client config");

--- a/packages/backend-lib/src/config.ts
+++ b/packages/backend-lib/src/config.ts
@@ -163,6 +163,12 @@ const BaseRawConfigProps = {
   clickhouseMaxBytesBeforeExternalGroupBy: Type.Optional(
     Type.String({ format: "naturalNumber" }),
   ),
+  clickhouseMaxExecutionTime: Type.Optional(
+    Type.String({ format: "naturalNumber" }),
+  ),
+  clickhouseMaxMemoryUsage: Type.Optional(
+    Type.String({ format: "naturalNumber" }),
+  ),
   computePropertiesSplit: Type.Optional(BoolStr),
   computePropertiesTimeout: Type.Optional(
     Type.String({ format: "naturalNumber" }),
@@ -312,6 +318,8 @@ export type Config = Overwrite<
     clickhouseComputePropertiesRequestTimeout?: number;
     clickhouseComputePropertiesMaxExecutionTime?: number;
     clickhouseMaxBytesRatioBeforeExternalGroupBy?: number;
+    clickhouseMaxExecutionTime: number;
+    clickhouseMaxMemoryUsage: string;
     computePropertiesSplit: boolean;
     computePropertiesTimeout: number;
     waitForComputePropertiesBaseDelayMs: number;
@@ -710,6 +718,13 @@ function parseRawConfig(rawConfig: RawConfig): Config {
       rawConfig.clickhouseMaxBytesRatioBeforeExternalGroupBy
         ? parseFloat(rawConfig.clickhouseMaxBytesRatioBeforeExternalGroupBy)
         : undefined,
+    // 5 minutes
+    clickhouseMaxExecutionTime: rawConfig.clickhouseMaxExecutionTime
+      ? parseInt(rawConfig.clickhouseMaxExecutionTime)
+      : 300,
+    // 10 GB
+    clickhouseMaxMemoryUsage:
+      rawConfig.clickhouseMaxMemoryUsage ?? "10000000000",
     computePropertiesSplit: rawConfig.computePropertiesSplit === "true",
     computePropertiesTimeout: rawConfig.computePropertiesTimeout
       ? parseInt(rawConfig.computePropertiesTimeout)


### PR DESCRIPTION
- Add clickhouseMaxExecutionTime config (default 300s)
- Add clickhouseMaxMemoryUsage config (default 10GB)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable limits for ClickHouse queries and applies them to the client.
> 
> - Adds `clickhouseMaxExecutionTime` and `clickhouseMaxMemoryUsage` to config schema/types with defaults (300s, 10GB)
> - Passes these values to ClickHouse via `clickhouse_settings` (`max_execution_time`, `max_memory_usage`) in `clickhouse.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab7d0cfe713544ede55d65f9dd29b2d14bbdcdf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->