### PR TITLE
Load root .env in dashboard dev/test mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "react-dom": "18.3.1",
     "react-is": "18.3.1",
     "date-fns-tz": "2.0.0",
-    "@fastify/cookie": "9.0.4"
+    "@fastify/cookie": "9.0.4",
+    "dotenv": "16.0.3"
   },
   "packageManager": "yarn@4.1.1"
 }

--- a/packages/dashboard/next.config.js
+++ b/packages/dashboard/next.config.js
@@ -1,5 +1,10 @@
 const path = require("path");
 
+// Load root .env file in development and test environments
+if (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test") {
+  require("dotenv").config({ path: path.join(__dirname, "../../.env") });
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   typescript: {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_ENV=development next dev",
     "build": "next build",
     "start": "next start",
     "check": "tsc --build",
@@ -108,6 +108,7 @@
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",
     "copyfiles": "^2.4.1",
+    "dotenv": "^16.0.3",
     "eslint": "^8.43.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15185,6 +15185,7 @@ __metadata:
     dagre: "npm:^0.8.5"
     date-fns: "npm:^2.29.3"
     date-fns-tz: "npm:^2.0.0"
+    dotenv: "npm:^16.0.3"
     drizzle-orm: "npm:^0.38.3"
     emailo: "npm:0.0.1"
     escape-html: "npm:^1.0.3"
@@ -15817,7 +15818,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.3":
+"dotenv@npm:16.0.3":
   version: 16.0.3
   resolution: "dotenv@npm:16.0.3"
   checksum: 10/d6788c8e40b35ad9a9ca29249dccf37fa6b3ad26700fcbc87f2f41101bf914f5193a04e36a3d23de70b1dcb8e5d5a3b21e151debace2c4cd08d868be500a1b29


### PR DESCRIPTION
- Add dotenv loading in next.config.js for dev/test
- Set NODE_ENV=development in dashboard dev script
- Add dotenv resolution to prevent version conflicts
