### PR TITLE
Use dotenv-cli for dashboard dev startup

### DIFF
--- a/packages/dashboard/next.config.js
+++ b/packages/dashboard/next.config.js
@@ -1,10 +1,5 @@
 const path = require("path");
 
-// Load root .env file in development and test environments
-if (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test") {
-  require("dotenv").config({ path: path.join(__dirname, "../../.env") });
-}
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   typescript: {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_ENV=development next dev",
+    "dev": "NODE_ENV=development dotenv -e ../../.env -- next dev",
     "build": "next build",
     "start": "next start",
     "check": "tsc --build",
@@ -109,6 +109,7 @@
     "@typescript-eslint/parser": "^5.60.0",
     "copyfiles": "^2.4.1",
     "dotenv": "^16.0.3",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^8.43.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14891,6 +14891,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-spawn@npm:^7.0.6":
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
+  dependencies:
+    path-key: "npm:^3.1.0"
+    shebang-command: "npm:^2.0.0"
+    which: "npm:^2.0.1"
+  checksum: 10/0d52657d7ae36eb130999dffff1168ec348687b48dd38e2ff59992ed916c88d328cf1d07ff4a4a10bc78de5e1c23f04b306d569e42f7a2293915c081e4dfee86
+  languageName: node
+  linkType: hard
+
 "crypt@npm:0.0.2":
   version: 0.0.2
   resolution: "crypt@npm:0.0.2"
@@ -15186,6 +15197,7 @@ __metadata:
     date-fns: "npm:^2.29.3"
     date-fns-tz: "npm:^2.0.0"
     dotenv: "npm:^16.0.3"
+    dotenv-cli: "npm:^11.0.0"
     drizzle-orm: "npm:^0.38.3"
     emailo: "npm:0.0.1"
     escape-html: "npm:^1.0.3"
@@ -15815,6 +15827,29 @@ __metadata:
     no-case: "npm:^3.0.4"
     tslib: "npm:^2.0.3"
   checksum: 10/a65e3519414856df0228b9f645332f974f2bf5433370f544a681122eab59e66038fc3349b4be1cdc47152779dac71a5864f1ccda2f745e767c46e9c6543b1169
+  languageName: node
+  linkType: hard
+
+"dotenv-cli@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "dotenv-cli@npm:11.0.0"
+  dependencies:
+    cross-spawn: "npm:^7.0.6"
+    dotenv: "npm:^17.1.0"
+    dotenv-expand: "npm:^12.0.0"
+    minimist: "npm:^1.2.6"
+  bin:
+    dotenv: cli.js
+  checksum: 10/0dab973aa8d94163f9b17f7452f9c9b567baf67e6551c3d883f3ea1df9edbd69a9ea55cbc8e020026c9e8d8f01056087526d011c1829924483c8c72f9c17c79a
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:^12.0.0":
+  version: 12.0.3
+  resolution: "dotenv-expand@npm:12.0.3"
+  dependencies:
+    dotenv: "npm:^16.4.5"
+  checksum: 10/d9aaf051805c8fa64e7e3620936ecb38229a93f5603883e53856d6f57cd4ae93fb74baefdf0b03b1c0608bc3eefbbcb23912972d7303b6191a5c0e1688a8652f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Load root .env before Next.js CLI parses PORT
- Remove redundant dotenv loading from next.config.js
