### PR TITLE
Add broadcastId to template preview tags

### DIFF
--- a/packages/dashboard/src/components/templateEditor.tsx
+++ b/packages/dashboard/src/components/templateEditor.tsx
@@ -317,6 +317,7 @@ function buildTags({
   userId?: string;
 }): Record<string, string> {
   return {
+    broadcastId: "sample-broadcast-id",
     journeyId: "sample-journey-id",
     messageId: "sample-message-id",
     nodeId: "sample-node-id",


### PR DESCRIPTION
- Fix preview error when using {{ tags.broadcastId }} in templates
- Closes #1812