### PR TITLE
Exclude command palette from public routes

### DIFF
--- a/packages/dashboard/src/components/app.tsx
+++ b/packages/dashboard/src/components/app.tsx
@@ -14,7 +14,6 @@ import { Provider as StoreProvider, useCreateStore } from "../lib/appStore";
 import createEmotionCache from "../lib/createEmotionCache";
 import { PreloadedState } from "../lib/types";
 import ThemeCustomization from "../themeCustomization";
-import { CommandPaletteProvider } from "./commandPalette";
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
@@ -231,9 +230,7 @@ export default function App({
           <SnackbarProvider preventDuplicate>
             <LocalizationProvider dateAdapter={AdapterDateFns}>
               <QueryClientProvider client={queryClient}>
-                <CommandPaletteProvider>
-                  <Component {...pageProps} />
-                </CommandPaletteProvider>
+                <Component {...pageProps} />
               </QueryClientProvider>
             </LocalizationProvider>
           </SnackbarProvider>

--- a/packages/dashboard/src/components/dashboardContent.tsx
+++ b/packages/dashboard/src/components/dashboardContent.tsx
@@ -1,3 +1,4 @@
+import { CommandPaletteProvider } from "./commandPalette";
 import DashboardHead from "./dashboardHead";
 import MainLayout from "./mainLayout";
 
@@ -7,11 +8,11 @@ export default function DashboardContent({
   children?: React.ReactNode;
 }) {
   return (
-    <>
+    <CommandPaletteProvider>
       <DashboardHead />
       <MainLayout>
         <>{children}</>
       </MainLayout>
-    </>
+    </CommandPaletteProvider>
   );
 }


### PR DESCRIPTION
- Move CommandPaletteProvider from app.tsx to dashboardContent.tsx
- Public pages like /public/subscription-management no longer load the command palette