### PR TITLE
fix: add workspaceId filter to prevent cross-workspace IDOR (#1828)

### DIFF
--- a/packages/api/src/controllers/broadcastsController.ts
+++ b/packages/api/src/controllers/broadcastsController.ts
@@ -38,7 +38,7 @@ import {
   UpdateBroadcastRequest,
   UpsertBroadcastV2Request,
 } from "backend-lib/src/types";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { FastifyInstance } from "fastify";
 import { v5 as uuidv5 } from "uuid";
 
@@ -123,7 +123,12 @@ export default async function broadcastsController(fastify: FastifyInstance) {
         .set({
           name: request.body.name,
         })
-        .where(eq(schema.broadcast.id, request.body.id))
+        .where(
+          and(
+            eq(schema.broadcast.id, request.body.id),
+            eq(schema.broadcast.workspaceId, request.body.workspaceId),
+          ),
+        )
         .returning();
       if (!broadcast) {
         return reply.status(404).send({

--- a/packages/api/src/controllers/contentController.ts
+++ b/packages/api/src/controllers/contentController.ts
@@ -285,7 +285,10 @@ export default async function contentController(fastify: FastifyInstance) {
         const { journeyId, nodeId } = journeyMetadata;
         await db().transaction(async (tx) => {
           const journey = await tx.query.journey.findFirst({
-            where: eq(schema.journey.id, journeyId),
+            where: and(
+              eq(schema.journey.id, journeyId),
+              eq(schema.journey.workspaceId, request.body.workspaceId),
+            ),
           });
           if (!journey) {
             return;
@@ -310,7 +313,12 @@ export default async function contentController(fastify: FastifyInstance) {
             .set({
               definition: journeyDefinition,
             })
-            .where(eq(schema.journey.id, journeyId));
+            .where(
+              and(
+                eq(schema.journey.id, journeyId),
+                eq(schema.journey.workspaceId, request.body.workspaceId),
+              ),
+            );
         });
       }
       return reply.status(200).send(resource);

--- a/packages/api/src/controllers/subscriptionGroupsController.ts
+++ b/packages/api/src/controllers/subscriptionGroupsController.ts
@@ -143,7 +143,12 @@ export default async function subscriptionGroupsController(
     async (request, reply) => {
       const result = await db()
         .delete(schema.subscriptionGroup)
-        .where(eq(schema.subscriptionGroup.id, request.body.id))
+        .where(
+          and(
+            eq(schema.subscriptionGroup.id, request.body.id),
+            eq(schema.subscriptionGroup.workspaceId, request.body.workspaceId),
+          ),
+        )
         .returning();
       if (!result.length) {
         return reply.status(404).send();


### PR DESCRIPTION
## Summary

Fixes #1828 — cross-workspace IDOR in three controllers where resource mutations filtered by resource ID only, allowing an authenticated user from workspace A to mutate resources in workspace B by supplying a foreign resource ID with their own `workspaceId` (which passes the request-context middleware check).

## Affected endpoints

| Endpoint | File | Issue |
|---|---|---|
| `PUT /api/content/templates/reset` | `contentController.ts` | Journey lookup + update by `journeyId` only |
| `PUT /api/broadcasts` | `broadcastsController.ts` | Broadcast update by `id` only |
| `DELETE /api/subscription-groups` | `subscriptionGroupsController.ts` | Subscription group delete by `id` only |

## Fix

Added `workspaceId` to the WHERE clauses so query/update/delete only matches resources owned by the authenticated workspace. The `workspaceId` is taken from `request.body.workspaceId`, which is already validated by the request-context middleware against the authenticated session.

## Behavioral change

A request that previously succeeded silently across workspaces will now:
- For the journey reset: skip the journey update (early `return` on null journey) — message template upsert still succeeds, but the cross-workspace journey definition is no longer modified
- For broadcast update: return 404 (no row matched)
- For subscription group delete: return 404 (no row matched)

No legitimate single-workspace flow is affected — when `workspaceId` matches, behavior is unchanged.

## Test plan

- [ ] `yarn workspace api check` passes (verified locally)
- [ ] Integration test: user from workspace A cannot modify journey/broadcast/subscription-group from workspace B
- [ ] Regression test: user from workspace A can still modify their own resources