### PR TITLE
fix: pass cc and bcc to transport.sendMail() in SMTP destination

### DIFF
--- a/packages/backend-lib/src/destinations/smtp.ts
+++ b/packages/backend-lib/src/destinations/smtp.ts
@@ -40,6 +40,8 @@ export async function sendMail({
   attachments,
   replyTo,
   headers,
+  cc,
+  bcc,
 }: SendSmtpMailParams): Promise<Result<EmailSmtpSuccess, MessageSmtpFailure>> {
   const transport = createTransport({
     host,
@@ -61,6 +63,8 @@ export async function sendMail({
       replyTo,
       headers,
       attachments,
+      cc,
+      bcc,
     });
 
     return ok({


### PR DESCRIPTION
## Summary

`SendSmtpMailParams` accepts optional `cc` and `bcc` string arrays (added in #1207 *"support cc and bcc"*), but the `sendMail()` function in `destinations/smtp.ts` did not:

1. Destructure `cc` / `bcc` from the params, and
2. Forward them to `transport.sendMail()`.

As a result, **CC and BCC recipients have been silently ignored for every SMTP email since #1207 was merged**. Other providers (SES, Resend, etc.) wire `cc`/`bcc` through correctly, so the bug is SMTP-specific.

## Fix

Two-line change: destructure `cc, bcc` and forward them to nodemailer's `sendMail()`.

## Verification

- `yarn workspace backend-lib check` passes locally
- No behavioral change for senders not passing `cc`/`bcc` (the params are optional and remain `undefined`)
- Senders that already pass `cc`/`bcc` (which currently no-op) will now actually deliver to CC/BCC recipients