### PR TITLE
Chunk createPeriods writes to stay under the Postgres bind-parameter limit

### DIFF
--- a/packages/backend-lib/src/computedProperties/periods.test.ts
+++ b/packages/backend-lib/src/computedProperties/periods.test.ts
@@ -4,7 +4,11 @@ import { unwrap } from "isomorphic-lib/src/resultHandling/resultUtils";
 
 import config, { type Config } from "../config";
 import { db, insert } from "../db";
-import { segment as dbSegment, workspace as dbWorkspace } from "../db/schema";
+import {
+  computedPropertyPeriod as dbComputedPropertyPeriod,
+  segment as dbSegment,
+  workspace as dbWorkspace,
+} from "../db/schema";
 import { toSegmentResource } from "../segments";
 import {
   ComputedPropertyStepEnum,
@@ -18,6 +22,7 @@ import {
   findDueWorkspaceMinTos,
   getEarliestComputePropertyPeriod,
   getPeriodsByComputedPropertyId,
+  PERIOD_CHUNK_SIZE,
 } from "./periods";
 
 interface ActualConfigModule {
@@ -479,5 +484,61 @@ describe("periods", () => {
         resetConfigMock();
       }
     });
+  });
+
+  describe("createPeriods", () => {
+    it(
+      "inserts every period when there are more computed properties than fit " +
+        "in a single query's bind parameter budget",
+      async () => {
+        const segmentDb = unwrap(
+          await insert({
+            table: dbSegment,
+            values: {
+              id: randomUUID(),
+              workspaceId: workspace.id,
+              name: `segment-${randomUUID()}`,
+              definition: {
+                entryNode: {
+                  id: "1",
+                  type: SegmentNodeType.Trait,
+                  path: "email",
+                  operator: {
+                    type: SegmentOperatorType.Equals,
+                    value: "example@test.com",
+                  },
+                },
+                nodes: [],
+              },
+              updatedAt: new Date(),
+            },
+          }),
+        );
+        const baseSegment = unwrap(toSegmentResource(segmentDb));
+        // Two chunks. 10,000 rows is 90,000 bind parameters, well past the
+        // 65,535 postgres accepts in one query, so an unchunked insert would
+        // corrupt the wire protocol instead of erroring.
+        const segments: SavedSegmentResource[] = Array.from(
+          { length: PERIOD_CHUNK_SIZE * 2 },
+          () => ({ ...baseSegment, id: randomUUID() }),
+        );
+
+        await createPeriods({
+          workspaceId: workspace.id,
+          segments,
+          userProperties: [],
+          now: Date.now(),
+          step: ComputedPropertyStepEnum.ComputeAssignments,
+        });
+
+        const created = await db()
+          .select({ id: dbComputedPropertyPeriod.id })
+          .from(dbComputedPropertyPeriod)
+          .where(eq(dbComputedPropertyPeriod.workspaceId, workspace.id));
+
+        expect(created).toHaveLength(segments.length);
+      },
+      30000,
+    );
   });
 });

--- a/packages/backend-lib/src/computedProperties/periods.ts
+++ b/packages/backend-lib/src/computedProperties/periods.ts
@@ -12,6 +12,7 @@ import {
   SQL,
   sql,
 } from "drizzle-orm";
+import * as R from "remeda";
 import { Overwrite } from "utility-types";
 
 import config from "../config";
@@ -192,6 +193,16 @@ export async function getPeriodsByComputedPropertyId({
   return pbcpp;
 }
 
+/**
+ * Postgres allows at most 65,535 bind parameters per query. ComputedPropertyPeriod
+ * has 9 columns, so a single insert tops out at 7,281 rows (9 * 7,281 < 65,535), and
+ * a workspace with more segments + user properties than that silently corrupts the
+ * wire protocol rather than erroring: node-postgres writes the parameter count as an
+ * unchecked int16, so it wraps modulo 65,536 and the server reads a misaligned frame.
+ * 5,000 rows is 45,000 parameters, 69% of the limit.
+ */
+export const PERIOD_CHUNK_SIZE = 5000;
+
 export async function createPeriods({
   workspaceId,
   userProperties,
@@ -262,24 +273,30 @@ export async function createPeriods({
     (p) => p.computedPropertyId,
   );
   await db().transaction(async (tx) => {
-    await tx
-      .insert(dbComputedPropertyPeriod)
-      .values(newPeriods)
-      .onConflictDoNothing();
+    for (const chunk of R.chunk(newPeriods, PERIOD_CHUNK_SIZE)) {
+      // eslint-disable-next-line no-await-in-loop
+      await tx
+        .insert(dbComputedPropertyPeriod)
+        .values(chunk)
+        .onConflictDoNothing();
+    }
     logger().debug("Deleted periods");
-    await tx
-      .delete(dbComputedPropertyPeriod)
-      .where(
-        and(
-          eq(dbComputedPropertyPeriod.workspaceId, workspaceId),
-          eq(dbComputedPropertyPeriod.step, step),
-          inArray(
-            dbComputedPropertyPeriod.computedPropertyId,
-            insertedComputedPropertyIds,
+    for (const idChunk of R.chunk(
+      insertedComputedPropertyIds,
+      PERIOD_CHUNK_SIZE,
+    )) {
+      // eslint-disable-next-line no-await-in-loop
+      await tx
+        .delete(dbComputedPropertyPeriod)
+        .where(
+          and(
+            eq(dbComputedPropertyPeriod.workspaceId, workspaceId),
+            eq(dbComputedPropertyPeriod.step, step),
+            inArray(dbComputedPropertyPeriod.computedPropertyId, idChunk),
+            lt(dbComputedPropertyPeriod.to, new Date(now - 60 * 1000 * 5)),
           ),
-          lt(dbComputedPropertyPeriod.to, new Date(now - 60 * 1000 * 5)),
-        ),
-      );
+        );
+    }
   });
 }
 


### PR DESCRIPTION
## Problem

`createPeriods` inserts one `ComputedPropertyPeriod` row per computed property in a single statement. The table has 9 columns, so 9 bind parameters per row against Postgres' 65,535-parameter ceiling — a workspace tops out at **7,281 computed properties**.

Past that, `node-postgres` does not raise a clean error: `addInt16` in `pg-protocol` writes the parameter count as an unchecked 16-bit value, so it wraps modulo 65,536 and the server reads a misaligned frame. On a workspace that had accumulated 10,455 segments we got:

```
bind message has 28721 parameter formats but 0 parameters
```

(9 × 10,473 = 94,257 parameters; 94,257 mod 65,536 = 28,721 — the number in the error names neither the cause nor the row count.) A second symptom was the worker being OOM-killed while building the parameter array. This cost us a 16.5-hour compute outage on that workspace.

## Fix

Chunk both the insert and the paired `delete … where "computedPropertyId" in (…)` into 5,000-row batches using `remeda`'s `R.chunk` — already the chunking idiom in `backend-lib`. Both loops stay inside the existing transaction, so semantics are unchanged.

## Test

Ships with a test inserting 10,000 periods: on unpatched code it fails with `bind message has 24464 parameter formats but 0 parameters` (90,000 mod 65,536), and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
